### PR TITLE
fix: remove token from authentication error message

### DIFF
--- a/crates/service/src/api/grpc/grpc_service.rs
+++ b/crates/service/src/api/grpc/grpc_service.rs
@@ -202,9 +202,10 @@ impl<SP: SpawnApi> MetaServiceImpl<SP> {
             .and_then(|b| String::from_utf8(b.to_vec()).ok())
             .ok_or_else(|| Status::unauthenticated("Error auth-token-bin is empty"))?;
 
-        let claim = self.token.try_verify_token(&token).map_err(|e| {
-            Status::unauthenticated(format!("token verify failed: {}, {}", token, e))
-        })?;
+        let claim = self
+            .token
+            .try_verify_token(&token)
+            .map_err(|e| Status::unauthenticated(format!("token verify failed: {}", e)))?;
         Ok(claim)
     }
 


### PR DESCRIPTION

## Changelog

##### fix: remove token from authentication error message
Authentication tokens were being included in error messages when token
verification failed, potentially exposing credentials in logs and error
responses.

Changes:
- Remove `token` from the `token verify failed` error format string

- Fix: #20

---

- Bug Fix
