### PR TITLE
refactor: stop re-exporting entire sled crate publicly

### DIFF
--- a/crates/raft-store/src/key_spaces.rs
+++ b/crates/raft-store/src/key_spaces.rs
@@ -28,10 +28,10 @@
 
 use std::io;
 
+use databend_meta_sled_store::IVec;
 use databend_meta_sled_store::SledKeySpace;
 use databend_meta_sled_store::SledOrderedSerde;
 use databend_meta_sled_store::SledSerde;
-use databend_meta_sled_store::sled;
 use databend_meta_types::SeqNum;
 use databend_meta_types::SeqV;
 use databend_meta_types::node::Node;
@@ -233,7 +233,7 @@ pub enum SMEntry {
 impl SMEntry {
     /// Serialize a key-value entry into a two elt vec of `Vec<u8>`: `[key, value]`.
     #[rustfmt::skip]
-    pub fn serialize(kv: &SMEntry) -> Result<(sled::IVec, sled::IVec), io::Error> {
+    pub fn serialize(kv: &SMEntry) -> Result<(IVec, IVec), io::Error> {
 
         match kv {
             Self::DataHeader       { key, value } => serialize_for_sled!(DataHeader,       key, value),
@@ -338,7 +338,7 @@ impl RaftStoreEntry {
 
     /// Serialize a key-value entry into a two elt vec of `Vec<u8>`: `[key, value]`.
     #[rustfmt::skip]
-    pub fn serialize(kv: &RaftStoreEntry) -> Result<(sled::IVec, sled::IVec), io::Error> {
+    pub fn serialize(kv: &RaftStoreEntry) -> Result<(IVec, IVec), io::Error> {
 
         match kv {
             Self::DataHeader       { key, value } => serialize_for_sled!(DataHeader,       key, value),

--- a/crates/raft-store/src/ondisk/header.rs
+++ b/crates/raft-store/src/ondisk/header.rs
@@ -14,9 +14,9 @@
 
 use std::fmt;
 
+use databend_meta_sled_store::IVec;
 use databend_meta_sled_store::SledBytesError;
 use databend_meta_sled_store::SledSerde;
-use databend_meta_sled_store::sled;
 
 use crate::ondisk::DATA_VERSION;
 use crate::ondisk::DataVersion;
@@ -59,7 +59,7 @@ impl fmt::Display for Header {
 }
 
 impl SledSerde for Header {
-    fn ser(&self) -> Result<sled::IVec, SledBytesError> {
+    fn ser(&self) -> Result<IVec, SledBytesError> {
         let x = serde_json::to_vec(self)?;
         Ok(x.into())
     }

--- a/crates/raft-store/src/state/raft_state_kv.rs
+++ b/crates/raft-store/src/state/raft_state_kv.rs
@@ -14,17 +14,16 @@
 
 use std::fmt;
 
+use databend_meta_sled_store::IVec;
 use databend_meta_sled_store::SledBytesError;
 use databend_meta_sled_store::SledOrderedSerde;
 use databend_meta_sled_store::SledSerde;
-use databend_meta_sled_store::sled;
 use databend_meta_types::anyerror::AnyError;
 use databend_meta_types::raft_types::LogId;
 use databend_meta_types::raft_types::NodeId;
 use databend_meta_types::raft_types::Vote;
 use serde::Deserialize;
 use serde::Serialize;
-use sled::IVec;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum RaftStateKey {

--- a/crates/raft-store/src/state_machine/log_meta.rs
+++ b/crates/raft-store/src/state_machine/log_meta.rs
@@ -14,15 +14,14 @@
 
 use std::fmt;
 
+use databend_meta_sled_store::IVec;
 use databend_meta_sled_store::SledBytesError;
 use databend_meta_sled_store::SledOrderedSerde;
 use databend_meta_sled_store::SledSerde;
-use databend_meta_sled_store::sled;
 use databend_meta_types::anyerror::AnyError;
 use databend_meta_types::raft_types::LogId;
 use serde::Deserialize;
 use serde::Serialize;
-use sled::IVec;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum LogMetaKey {

--- a/crates/raft-store/src/state_machine/state_machine_meta.rs
+++ b/crates/raft-store/src/state_machine/state_machine_meta.rs
@@ -14,16 +14,15 @@
 
 use std::fmt;
 
+use databend_meta_sled_store::IVec;
 use databend_meta_sled_store::SledBytesError;
 use databend_meta_sled_store::SledOrderedSerde;
 use databend_meta_sled_store::SledSerde;
-use databend_meta_sled_store::sled;
 use databend_meta_types::anyerror::AnyError;
 use databend_meta_types::raft_types::LogId;
 use databend_meta_types::raft_types::StoredMembership;
 use serde::Deserialize;
 use serde::Serialize;
-use sled::IVec;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum StateMachineMetaKey {

--- a/crates/raft-store/tests/it/types.rs
+++ b/crates/raft-store/tests/it/types.rs
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use databend_meta_sled_store::IVec;
 use databend_meta_sled_store::SledOrderedSerde;
-use databend_meta_sled_store::sled;
 use databend_meta_types::raft_types::NodeId;
 
 #[test]
 fn test_node_id_serde_ser() -> anyhow::Result<()> {
     let ids: Vec<NodeId> = vec![9, 10, 11];
 
-    let want: Vec<sled::IVec> = vec![
-        sled::IVec::from(vec![0, 0, 0, 0, 0, 0, 0, 9]),
-        sled::IVec::from(vec![0, 0, 0, 0, 0, 0, 0, 10]),
-        sled::IVec::from(vec![0, 0, 0, 0, 0, 0, 0, 11]),
+    let want: Vec<IVec> = vec![
+        IVec::from(vec![0, 0, 0, 0, 0, 0, 0, 9]),
+        IVec::from(vec![0, 0, 0, 0, 0, 0, 0, 10]),
+        IVec::from(vec![0, 0, 0, 0, 0, 0, 0, 11]),
     ];
     let got = ids.iter().map(|id| id.ser().unwrap()).collect::<Vec<_>>();
     assert_eq!(want, got);

--- a/crates/sled-store/src/lib.rs
+++ b/crates/sled-store/src/lib.rs
@@ -23,7 +23,7 @@ pub use db::get_sled_db;
 pub use db::init_get_sled_db;
 pub use db::init_sled_db;
 pub use openraft;
-pub use sled;
+pub use sled::IVec;
 pub use sled_key_space::SledKeySpace;
 pub use sled_serde::SledOrderedSerde;
 pub use sled_serde::SledSerde;


### PR DESCRIPTION

## Changelog

##### refactor: stop re-exporting entire sled crate publicly
The sled-store crate was publicly re-exporting the entire `sled` crate,
which leaked storage implementation details to consumers. Now only the
`IVec` type is exported, reducing the public API surface.

Changes:
- Replace `pub use sled;` with `pub use sled::IVec;` in sled-store
- Update consumers to import `IVec` directly from `databend_meta_sled_store`

- Fix: #32

---

- Improvement
