### PR TITLE
refactor: simplify size constant expressions

### DIFF
--- a/crates/raft-store/src/config.rs
+++ b/crates/raft-store/src/config.rs
@@ -193,7 +193,7 @@ impl Default for RaftConfig {
             raft_dir: "./.databend/meta".to_string(),
 
             log_cache_max_items: 1_000_000,
-            log_cache_capacity: 1 * GB,
+            log_cache_capacity: GB,
             log_wal_chunk_max_records: 100_000,
             log_wal_chunk_max_size: 256 * MB,
 
@@ -206,7 +206,7 @@ impl Default for RaftConfig {
             snapshot_db_debug_check: true,
             snapshot_db_block_keys: 8000,
             snapshot_db_block_cache_item: 1024,
-            snapshot_db_block_cache_size: 1 * GB,
+            snapshot_db_block_cache_size: GB,
 
             compact_immutables_ms: None,
             single: false,


### PR DESCRIPTION

## Changelog

##### refactor: simplify size constant expressions
Remove redundant multiplication by 1 for size constants to follow
idiomatic Rust style.

Changes:
- Simplify `1 * GB` to `GB` in `log_cache_capacity`
- Simplify `1 * GB` to `GB` in `snapshot_db_block_cache_size`

---

- Improvement
