### PR TITLE
change: remove version parameter from MetaGrpcClient creation

### DIFF
--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -17,6 +17,7 @@ chrono = { workspace = true }
 databend-base = { workspace = true }
 databend-meta-runtime-api = { workspace = true }
 databend-meta-types = { workspace = true }
+databend-meta-version = { workspace = true }
 derive_more = { workspace = true }
 display-more = { workspace = true }
 fastrace = { workspace = true }

--- a/crates/client/src/channel_manager.rs
+++ b/crates/client/src/channel_manager.rs
@@ -28,7 +28,6 @@ use databend_meta_types::protobuf::meta_service_client::MetaServiceClient;
 use log::info;
 use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
-use semver::Version;
 use tonic::async_trait;
 use tonic::transport::Channel;
 
@@ -51,7 +50,6 @@ pub const DEFAULT_CONNECTION_TTL: Duration = Duration::from_secs(20);
 
 #[derive(Debug)]
 pub struct MetaChannelManager<R> {
-    version: Version,
     username: String,
     password: String,
     timeout: Option<Duration>,
@@ -76,7 +74,6 @@ pub struct MetaChannelManager<R> {
 
 impl<R: SpawnApi> MetaChannelManager<R> {
     pub fn new(
-        version: Version,
         username: impl ToString,
         password: impl ToString,
         timeout: Option<Duration>,
@@ -86,7 +83,6 @@ impl<R: SpawnApi> MetaChannelManager<R> {
         connection_ttl: Option<Duration>,
     ) -> Self {
         Self {
-            version,
             username: username.to_string(),
             password: password.to_string(),
             timeout,
@@ -114,7 +110,7 @@ impl<R: SpawnApi> MetaChannelManager<R> {
 
         let handshake_res = handshake(
             &mut real_client,
-            &self.version,
+            databend_meta_version::semver(),
             self.required_features,
             &self.username,
             &self.password,

--- a/crates/client/src/client_conf.rs
+++ b/crates/client/src/client_conf.rs
@@ -14,8 +14,6 @@
 
 use std::time::Duration;
 
-use semver::Version;
-
 #[derive(Clone, Debug, Default)]
 pub struct RpcClientTlsConfig {
     pub rpc_tls_server_root_ca_cert: String,
@@ -32,7 +30,6 @@ impl RpcClientTlsConfig {
 pub struct RpcClientConf {
     pub embedded_dir: Option<String>,
     pub endpoints: Vec<String>,
-    pub version: Version,
     pub username: String,
     pub password: String,
     pub tls_conf: Option<RpcClientTlsConfig>,
@@ -61,11 +58,10 @@ impl RpcClientConf {
         self.endpoints.clone()
     }
 
-    pub fn empty(version: Version) -> Self {
+    pub fn empty() -> Self {
         Self {
             embedded_dir: None,
             endpoints: vec![],
-            version,
             username: "".to_string(),
             password: "".to_string(),
             tls_conf: None,

--- a/crates/client/src/client_handle.rs
+++ b/crates/client/src/client_handle.rs
@@ -41,6 +41,7 @@ use fastrace::Span;
 use log::debug;
 use log::error;
 use log::info;
+use semver::Version;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot;
 use tonic::codegen::BoxStream;
@@ -96,7 +97,12 @@ pub struct ClientHandle<RT: SpawnApi> {
 
 impl<RT: SpawnApi> Display for ClientHandle<RT> {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        write!(f, "ClientHandle({})", self.endpoints.join(","))
+        write!(
+            f,
+            "ClientHandle(v{};{})",
+            databend_meta_version::semver(),
+            self.endpoints.join(",")
+        )
     }
 }
 
@@ -107,6 +113,11 @@ impl<RT: SpawnApi> Drop for ClientHandle<RT> {
 }
 
 impl<RT: SpawnApi> ClientHandle<RT> {
+    /// Returns the version of this client.
+    pub fn version(&self) -> &'static Version {
+        databend_meta_version::semver()
+    }
+
     pub async fn list(&self, prefix: &str) -> Result<BoxStream<StreamItem>, MetaError> {
         let strm = self
             .request(Streamed(ListKVReq {

--- a/crates/client/tests/it/grpc_client.rs
+++ b/crates/client/tests/it/grpc_client.rs
@@ -151,10 +151,8 @@ fn new_client(
     addr: impl ToString,
     timeout: Option<Duration>,
 ) -> anyhow::Result<Arc<ClientHandle<TokioRuntime>>> {
-    let version = databend_meta_version::semver().clone();
     let client = MetaGrpcClient::<TokioRuntime>::try_create(
         vec![addr.to_string()],
-        version,
         "",
         "",
         timeout,

--- a/crates/service/tests/it/grpc/metasrv_connection_error.rs
+++ b/crates/service/tests/it/grpc/metasrv_connection_error.rs
@@ -146,7 +146,6 @@ async fn test_metasrv_one_client_leader_down() -> anyhow::Result<()> {
 fn make_client(addresses: Vec<String>) -> Result<Arc<ClientHandle<TokioRuntime>>, CreationError> {
     let client = MetaGrpcClient::<TokioRuntime>::try_create(
         addresses, // a1() will be shut down
-        databend_meta_version::semver().clone(),
         "root",
         "xxx",
         None,

--- a/crates/service/tests/it/grpc/metasrv_grpc_kv_api_restart_cluster.rs
+++ b/crates/service/tests/it/grpc/metasrv_grpc_kv_api_restart_cluster.rs
@@ -21,7 +21,6 @@ use databend_meta_client::ClientHandle;
 use databend_meta_client::MetaGrpcClient;
 use databend_meta_runtime_api::TokioRuntime;
 use databend_meta_types::UpsertKV;
-use databend_meta_version::semver;
 use log::info;
 use test_harness::test;
 use tokio::time::sleep;
@@ -162,7 +161,6 @@ async fn test_kv_api_restart_cluster_token_expired() -> anyhow::Result<()> {
     let tcs = start_metasrv_cluster::<TokioRuntime>(&[0, 1, 2]).await?;
     let client = MetaGrpcClient::<TokioRuntime>::try_create(
         vec![tcs[0].config.grpc.api_address().unwrap()],
-        semver().clone(),
         "root",
         "xxx",
         // Without timeout, the client will not be able to reconnect.

--- a/crates/service/tests/it/grpc/metasrv_grpc_tls.rs
+++ b/crates/service/tests/it/grpc/metasrv_grpc_tls.rs
@@ -20,7 +20,6 @@ use databend_meta_runtime_api::TokioRuntime;
 use databend_meta_types::MetaClientError;
 use databend_meta_types::MetaError;
 use databend_meta_types::MetaNetworkError;
-use databend_meta_version::semver;
 use test_harness::test;
 
 use crate::testing::meta_service_test_harness;
@@ -51,7 +50,6 @@ async fn test_tls_server() -> anyhow::Result<()> {
 
     let client = MetaGrpcClient::<TokioRuntime>::try_create(
         vec![addr],
-        semver().clone(),
         "root",
         "xxx",
         None,
@@ -89,7 +87,6 @@ async fn test_tls_client_config_failure() -> anyhow::Result<()> {
 
     let r = MetaGrpcClient::<TokioRuntime>::try_create(
         vec!["addr".to_string()],
-        semver().clone(),
         "root",
         "xxx",
         None,

--- a/crates/service/tests/it/grpc/metasrv_grpc_watch.rs
+++ b/crates/service/tests/it/grpc/metasrv_grpc_watch.rs
@@ -43,7 +43,6 @@ use databend_meta_types::protobuf::WatchRequest;
 use databend_meta_types::protobuf::watch_request::FilterType;
 use databend_meta_types::txn_condition;
 use databend_meta_types::txn_op;
-use databend_meta_version::semver;
 use log::info;
 use test_harness::test;
 use tokio::time::sleep;
@@ -662,7 +661,6 @@ fn add_event(key: &str, res_seq: u64, res_val: &str, meta: Option<KvMeta>) -> Ev
 fn make_client(addr: impl ToString) -> anyhow::Result<Arc<ClientHandle<TokioRuntime>>> {
     let client = MetaGrpcClient::<TokioRuntime>::try_create(
         vec![addr.to_string()],
-        semver().clone(),
         "root",
         "xxx",
         None,

--- a/crates/test-harness/src/service.rs
+++ b/crates/test-harness/src/service.rs
@@ -119,7 +119,6 @@ pub fn make_grpc_client<R: RuntimeApi>(
 ) -> Result<Arc<ClientHandle<R>>, CreationError> {
     let client = MetaGrpcClient::<R>::try_create(
         addresses,
-        semver().clone(),
         "root",
         "xxx",
         Some(Duration::from_secs(2)), // timeout
@@ -231,7 +230,6 @@ impl<R: RuntimeApi> MetaSrvTestContext<R> {
 
         let client = MetaGrpcClient::<R>::try_create(
             vec![addr],
-            semver().clone(),
             "root",
             "xxx",
             None,


### PR DESCRIPTION

## Changelog

##### change: remove version parameter from MetaGrpcClient creation
The client version is now obtained directly from the static semver()
function instead of being passed as a parameter. This simplifies the
API and ensures the version is always consistent with the crate version.

Changes:
- Remove `version` parameter from `MetaGrpcClient::try_create()`
- Remove `version` parameter from `MetaGrpcClient::try_create_with_features()`
- Remove `version` field from `RpcClientConf`
- Add `version()` method to `ClientHandle` and `MetaGrpcClient`
- Update `Display` impl to include version in output

Upgrade tip:

When creating a MetaGrpcClient, remove the version argument:

Before:
- `MetaGrpcClient::try_create(endpoints, version, username, password, ...)`
- `MetaGrpcClient::try_create_with_features(endpoints, version, username, ...)`
- `RpcClientConf { version, ... }`

After:
- `MetaGrpcClient::try_create(endpoints, username, password, ...)`
- `MetaGrpcClient::try_create_with_features(endpoints, username, ...)`
- `RpcClientConf { ... }` (no version field)

To access the client version, use the new `version()` method:
- `client.version()` returns `&'static semver::Version`

---


