### PR TITLE
chore: replace databend-base histogram with base2histogram crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,8 @@ databend-meta-types = { path = "crates/server/types" }
 databend-meta-version = { path = "crates/common/version" }
 
 # External dependencies from databendlabs forks
-databend-base = "0.2.10"
+base2histogram = "0.2.3"
+databend-base = "0.3.0"
 map-api = "0.4.2"
 openraft = { version = "=0.10.0-alpha.17", features = ["serde", "tracing-log"] }
 sled = { version = "0.34", default-features = false }
@@ -155,7 +156,7 @@ rpath = true
 
 [patch.crates-io]
 async-backtrace = { git = "https://github.com/datafuse-extras/async-backtrace.git", rev = "dea4553" }
-databend-base = { git = "https://github.com/databendlabs/databend-base", tag = "v0.2.10" }
+databend-base = { git = "https://github.com/databendlabs/databend-base", tag = "v0.3.0" }
 map-api = { git = "https://github.com/databendlabs/map-api", tag = "v0.4.2" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1" }
 state-machine-api = { git = "https://github.com/databendlabs/state-machine-api.git", tag = "v0.3.4" }

--- a/crates/server/service/Cargo.toml
+++ b/crates/server/service/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = { workspace = true }
 arrow-flight = { workspace = true }
 async-trait = { workspace = true }
 backon = { workspace = true }
+base2histogram = { workspace = true }
 chrono = { workspace = true }
 databend-base = { workspace = true }
 databend-meta-client = { workspace = true }

--- a/crates/server/service/src/analysis/request_histogram.rs
+++ b/crates/server/service/src/analysis/request_histogram.rs
@@ -20,10 +20,10 @@ use std::sync::Mutex;
 use std::time::Duration;
 use std::time::SystemTime;
 
+use base2histogram::Histogram;
+use base2histogram::PercentileStats;
 use chrono::DateTime;
 use chrono::Utc;
-use databend_base::histogram::Histogram;
-use databend_base::histogram::PercentileStats;
 use databend_meta_client::MetaGrpcReadReq;
 use databend_meta_types::TxnRequest;
 use databend_meta_types::UpsertKV;

--- a/crates/server/service/tests/it/meta_node/meta_node_replication.rs
+++ b/crates/server/service/tests/it/meta_node/meta_node_replication.rs
@@ -44,7 +44,6 @@ use log::info;
 use maplit::btreeset;
 use openraft::LogIdOptionExt;
 use openraft::ServerState;
-use openraft::async_runtime::WatchReceiver;
 use openraft::testing::log_id;
 use test_harness::test;
 
@@ -227,9 +226,11 @@ async fn test_raft_service_install_snapshot_v003() -> anyhow::Result<()> {
     assert_eq!(resp.vote, Vote::new_committed(10, 2));
 
     let meta_node = tc0.meta_node.as_ref().unwrap();
-    let m = meta_node.raft.metrics().borrow_watched().clone();
-
-    assert_eq!(Some(last_log_id), m.snapshot);
+    meta_node
+        .raft
+        .wait(timeout())
+        .snapshot(last_log_id, "snapshot is installed")
+        .await?;
 
     // Incomplete
 
@@ -318,9 +319,11 @@ async fn test_raft_service_install_snapshot_v004() -> anyhow::Result<()> {
     assert_eq!(vote, Vote::new_committed(10, 2));
 
     let meta_node = tc0.meta_node.as_ref().unwrap();
-    let m = meta_node.raft.metrics().borrow_watched().clone();
-
-    assert_eq!(Some(last_log_id), m.snapshot);
+    meta_node
+        .raft
+        .wait(timeout())
+        .snapshot(last_log_id, "snapshot is installed")
+        .await?;
 
     let (_endpoint, strm) = meta_node
         .handle_forwardable_request(ForwardRequest::<MetaGrpcReadReq> {


### PR DESCRIPTION

## Changelog

##### chore: replace databend-base histogram with base2histogram crate
The histogram module in databend-base is now published as the standalone
`base2histogram` crate. Switch to it to decouple from the omnibus
databend-base package for this functionality. Also upgrade databend-base
from 0.2.10 to 0.3.0.

---


