### PR TITLE
chore: upgrade rotbl to 0.2.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ raft-log = "0.3.0"
 rand = { version = "0.8.5", features = ["small_rng", "serde1"] }
 regex = "1.8.1"
 rmp-serde = "1.1.1"
-rotbl = { version = "0.2.9", features = [] }
+rotbl = { version = "0.2.10", features = [] }
 rustls = { version = "0.23.27", features = ["ring", "tls12"], default-features = false }
 semver = "1.0.14"
 seq-marked = { version = "0.3.5", features = ["seq-marked-serde", "seq-marked-bincode", "seqv-serde"] }

--- a/crates/server/raft-store/src/config.rs
+++ b/crates/server/raft-store/src/config.rs
@@ -120,15 +120,11 @@ pub struct RaftConfig {
     /// Default: 8000 keys per block.
     pub snapshot_db_block_keys: u64,
 
-    /// Number of blocks to cache in snapshot database.
-    ///
-    /// Higher values improve read performance but use more memory.
-    /// Default: 1024 blocks.
-    pub snapshot_db_block_cache_item: u64,
-
     /// Total cache size for snapshot blocks in bytes.
     ///
-    /// Controls memory usage for snapshot block caching.
+    /// Controls memory usage for snapshot block caching. Since rotbl 0.2.10
+    /// the block cache is weight-bounded by bytes (`moka::sync::Cache` with
+    /// a weigher), so this is the only cache sizing knob.
     /// Default: 1GB (1,073,741,824 bytes).
     pub snapshot_db_block_cache_size: u64,
 
@@ -211,7 +207,6 @@ impl Default for RaftConfig {
 
             snapshot_db_debug_check: true,
             snapshot_db_block_keys: 8000,
-            snapshot_db_block_cache_item: 1024,
             snapshot_db_block_cache_size: GB,
 
             compact_immutables_ms: None,
@@ -253,7 +248,6 @@ impl RaftConfig {
             )
             .with_block_cache_config(
                 rotbl::v001::BlockCacheConfig::default()
-                    .with_max_items(self.snapshot_db_block_cache_item as usize)
                     .with_capacity(self.snapshot_db_block_cache_size as usize),
             )
     }


### PR DESCRIPTION

## Changelog

##### chore: upgrade rotbl to 0.2.10
rotbl 0.2.10 replaces the block cache `Arc<Mutex<LruCache>>` with
`moka::sync::Cache` and the file reader `Arc<Mutex<BoxReader>>` with
a positional `BoxReaderAt` backed by `pread(2)` / `FileExt::seek_read`.
Concurrent cache misses on different blocks no longer serialize
behind a single file mutex, and same-block herds are coalesced via
moka's `try_get_with`. In the rotbl contention benchmark this lifts
Phase 2 random-get throughput from ~1,800 ops/s to ~136,000 ops/s at
64-way concurrency, and collapses the Phase 3 mixed scanner+getters
walltime from 29 s to 1.5 s.

For databend-meta this removes the rotbl-layer contribution to the
post-snapshot-replace apply stall investigated under the Grafana
trace `T245-N2.5004451387` (249.8 ms `WriterPermit` hold, 73 per-key
cleanups serialized through `file.lock()`). The tokio-scheduling
side of that stall (compactor-vs-apply cooperative starvation,
`MetaWorker.run` single-serial consumer, `clean_expired` per-item
await) is unchanged and still needs to be addressed separately.

`BlockCacheConfig::with_max_items` was removed upstream because
`moka` cannot enforce both an item-count bound and a byte-capacity
bound when using a weigher, and byte capacity is the constraint that
matters for a read cache. The corresponding `snapshot_db_block_cache_item`
field on `RaftConfig` is therefore dropped — the only remaining knob
is `snapshot_db_block_cache_size`.

Upgrade tip:

`RaftConfig::snapshot_db_block_cache_item` no longer exists. Callers
constructing `RaftConfig` programmatically should drop the field;
there is no CLI flag or config file binding to migrate. Byte
capacity via `snapshot_db_block_cache_size` remains the single knob
for sizing the snapshot block cache.

---


