### PR TITLE
chore: Bump Ver: 260312.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "260312.6.0"
+version = "260312.7.0"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "260312.5.0"
+version = "260312.6.0"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "crates/server/sled-store",
     "crates/server/raft-store",
     "crates/server/service",
+    "benchmark",
 ]
 
 # Workspace dependencies

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "databend-meta-benchmark"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+databend-meta-client = { workspace = true }
+databend-meta-runtime-api = { workspace = true }
+databend-meta-test-harness = { workspace = true }
+env_logger = { workspace = true }
+log = { workspace = true }
+rand = { workspace = true }
+tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/benchmark/src/bin/meta_worker_contention.rs
+++ b/benchmark/src/bin/meta_worker_contention.rs
@@ -1,0 +1,235 @@
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+use std::time::Instant;
+
+use databend_meta_client::ClientHandle;
+use databend_meta_client::DEFAULT_GRPC_MESSAGE_SIZE;
+use databend_meta_client::MetaGrpcClient;
+use databend_meta_client::kvapi::KvApiExt;
+use databend_meta_client::types::MatchSeq;
+use databend_meta_client::types::Operation;
+use databend_meta_client::types::UpsertKV;
+use databend_meta_runtime_api::TokioRuntime;
+use databend_meta_test_harness::MetaSrvTestContext;
+use databend_meta_test_harness::start_metasrv_with_context;
+use rand::Rng;
+use rand::SeedableRng;
+
+const NUM_WRITERS: usize = 4;
+const NUM_READERS: usize = 8;
+const BENCH_DURATION_SECS: u64 = 30;
+const WARMUP_KEYS: usize = 500;
+const VALUE_SIZE: usize = 4096;
+const SNAPSHOT_LOGS_SINCE_LAST: u64 = 100;
+
+fn make_value(seed: u64) -> Vec<u8> {
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
+    let mut buf = vec![0u8; VALUE_SIZE];
+    rng.fill(&mut buf[..]);
+    buf
+}
+
+fn make_key(i: u64) -> String {
+    format!("bench/{:08}", i)
+}
+
+async fn grpc_client(addr: &str) -> Arc<ClientHandle<TokioRuntime>> {
+    MetaGrpcClient::<TokioRuntime>::try_create(
+        vec![addr.to_string()],
+        "root",
+        "xxx",
+        None,
+        Some(Duration::from_secs(10)),
+        None,
+        DEFAULT_GRPC_MESSAGE_SIZE,
+    )
+    .expect("create grpc client")
+}
+
+async fn warmup(client: &Arc<ClientHandle<TokioRuntime>>, n: usize) {
+    eprintln!(
+        "Warming up: writing {} keys ({} bytes each)...",
+        n, VALUE_SIZE
+    );
+    for i in 0..n as u64 {
+        let key = make_key(i);
+        let val = make_value(i);
+        client
+            .upsert_kv(UpsertKV::new(
+                &key,
+                MatchSeq::Any,
+                Operation::Update(val),
+                None,
+            ))
+            .await
+            .expect("warmup upsert");
+
+        if (i + 1) % 100 == 0 {
+            eprintln!("  warm-up: {}/{}", i + 1, n);
+        }
+    }
+    eprintln!("Warm-up done.\n");
+}
+
+async fn writer_task(
+    client: Arc<ClientHandle<TokioRuntime>>,
+    stop: Arc<AtomicBool>,
+    key_counter: Arc<AtomicU64>,
+) -> Vec<Duration> {
+    let mut latencies = Vec::new();
+
+    while !stop.load(Ordering::Relaxed) {
+        let i = key_counter.fetch_add(1, Ordering::Relaxed);
+        let key = make_key(i);
+        let val = make_value(i);
+
+        let t = Instant::now();
+        let res = client
+            .upsert_kv(UpsertKV::new(
+                &key,
+                MatchSeq::Any,
+                Operation::Update(val),
+                None,
+            ))
+            .await;
+        let elapsed = t.elapsed();
+
+        if res.is_ok() {
+            latencies.push(elapsed);
+        }
+    }
+
+    latencies
+}
+
+async fn reader_task(
+    client: Arc<ClientHandle<TokioRuntime>>,
+    stop: Arc<AtomicBool>,
+    max_key: Arc<AtomicU64>,
+) -> Vec<Duration> {
+    let mut latencies = Vec::new();
+    let mut rng = rand::rngs::SmallRng::from_entropy();
+
+    while !stop.load(Ordering::Relaxed) {
+        let hi = max_key.load(Ordering::Relaxed);
+        if hi == 0 {
+            tokio::task::yield_now().await;
+            continue;
+        }
+        let i = rng.gen_range(0..hi);
+        let key = make_key(i);
+
+        let t = Instant::now();
+        let res = client.get_kv(&key).await;
+        let elapsed = t.elapsed();
+
+        if res.is_ok() {
+            latencies.push(elapsed);
+        }
+    }
+
+    latencies
+}
+
+fn report(label: &str, mut latencies: Vec<Duration>) {
+    if latencies.is_empty() {
+        eprintln!("{}: no samples", label);
+        return;
+    }
+    latencies.sort();
+    let n = latencies.len();
+    let p = |pct: f64| -> Duration {
+        let idx = ((n as f64) * pct / 100.0).ceil() as usize;
+        latencies[idx.min(n - 1)]
+    };
+    eprintln!(
+        "{:>8}: {:>6} ops  |  p50 {:>8.2?}  p90 {:>8.2?}  p99 {:>8.2?}  p999 {:>8.2?}  max {:>8.2?}",
+        label,
+        n,
+        p(50.0),
+        p(90.0),
+        p(99.0),
+        p(99.9),
+        latencies[n - 1],
+    );
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn"))
+        .format_timestamp_millis()
+        .init();
+
+    eprintln!("=== MetaWorker contention benchmark ===\n");
+    eprintln!(
+        "Writers: {}, Readers: {}, Duration: {}s, Value size: {}B",
+        NUM_WRITERS, NUM_READERS, BENCH_DURATION_SECS, VALUE_SIZE
+    );
+    eprintln!("snapshot_logs_since_last: {}\n", SNAPSHOT_LOGS_SINCE_LAST);
+
+    let mut tc = MetaSrvTestContext::<TokioRuntime>::new(0);
+    tc.config.raft_config.snapshot_logs_since_last = SNAPSHOT_LOGS_SINCE_LAST;
+    tc.config.raft_config.max_applied_log_to_keep = 0;
+    tc.config.raft_config.single = true;
+
+    start_metasrv_with_context(&mut tc).await?;
+
+    let addr = tc.config.grpc.api_address().expect("grpc address");
+
+    eprintln!("Meta-service started at {}\n", addr);
+
+    let client = grpc_client(&addr).await;
+
+    warmup(&client, WARMUP_KEYS).await;
+
+    // key_counter starts after warmup range so writers create new keys
+    let key_counter = Arc::new(AtomicU64::new(WARMUP_KEYS as u64));
+    let stop = Arc::new(AtomicBool::new(false));
+
+    eprintln!("Running benchmark for {}s ...\n", BENCH_DURATION_SECS);
+
+    let mut handles = Vec::new();
+
+    for _ in 0..NUM_WRITERS {
+        let c = grpc_client(&addr).await;
+        let s = stop.clone();
+        let kc = key_counter.clone();
+        handles.push(tokio::spawn(async move {
+            ("write", writer_task(c, s, kc).await)
+        }));
+    }
+
+    for _ in 0..NUM_READERS {
+        let c = grpc_client(&addr).await;
+        let s = stop.clone();
+        let mk = key_counter.clone();
+        handles.push(tokio::spawn(async move {
+            ("read", reader_task(c, s, mk).await)
+        }));
+    }
+
+    tokio::time::sleep(Duration::from_secs(BENCH_DURATION_SECS)).await;
+    stop.store(true, Ordering::Relaxed);
+
+    let mut all_writes = Vec::new();
+    let mut all_reads = Vec::new();
+
+    for h in handles {
+        let (label, lats) = h.await?;
+        match label {
+            "write" => all_writes.extend(lats),
+            "read" => all_reads.extend(lats),
+            _ => {}
+        }
+    }
+
+    eprintln!("=== Results ===\n");
+    report("Writes", all_writes);
+    report("Reads", all_reads);
+    eprintln!();
+
+    Ok(())
+}

--- a/crates/common/version/src/grpc_changelog.rs
+++ b/crates/common/version/src/grpc_changelog.rs
@@ -94,6 +94,18 @@ pub fn grpc_changelog() -> BTreeMap<Version, GrpcVersionCompat> {
         min_server: ver(260217, 0, 0),
     });
 
+    // 260312.6.0: no compatibility change
+    m.insert(ver(260312, 6, 0), GrpcVersionCompat {
+        min_client: ver(1, 2, 676),
+        min_server: ver(260217, 0, 0),
+    });
+
+    // 260312.7.0: no compatibility change
+    m.insert(ver(260312, 7, 0), GrpcVersionCompat {
+        min_client: ver(1, 2, 676),
+        min_server: ver(260217, 0, 0),
+    });
+
     m
 }
 

--- a/crates/common/version/src/lib.rs
+++ b/crates/common/version/src/lib.rs
@@ -140,17 +140,17 @@ mod tests {
 
     #[test]
     fn test_version_string() {
-        assert_eq!(version_str(), "260312.5.0");
+        assert_eq!(version_str(), "260312.7.0");
     }
 
     #[test]
     fn test_semver_components() {
-        assert_eq!(semver_tuple(version()), (260312, 5, 0));
+        assert_eq!(semver_tuple(version()), (260312, 7, 0));
     }
 
     #[test]
     fn test_semver_display() {
-        assert_eq!(version().to_semver().to_string(), "260312.5.0");
+        assert_eq!(version().to_semver().to_string(), "260312.7.0");
     }
 
     #[test]

--- a/crates/server/raft-store/src/utils.rs
+++ b/crates/server/raft-store/src/utils.rs
@@ -37,13 +37,10 @@ where
     T: Send + 'static,
 {
     stream.enumerate().then(move |(index, item)| {
-        // Yield control every n items to prevent blocking other tasks
-        let to_yield = if index > 0 && index % 5000 == 0 {
-            info!("{stream_name} yield control to allow other tasks to run: index={index}");
-            true
-        } else {
-            false
-        };
+        if index > 0 && index % 10_000 == 0 {
+            info!("{stream_name} processed {index} items");
+        }
+        let to_yield = index > 0 && index % 100 == 0;
 
         async move {
             if to_yield {

--- a/crates/server/service/src/meta_node/meta_worker.rs
+++ b/crates/server/service/src/meta_node/meta_worker.rs
@@ -18,6 +18,7 @@ use databend_meta_raft_store::MetaStartupError;
 use databend_meta_runtime_api::RuntimeApi;
 use log::error;
 use log::info;
+use tokio::sync::Semaphore;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 
@@ -98,9 +99,26 @@ impl<RT: RuntimeApi> MetaWorker<RT> {
         Ok(meta_handle)
     }
 
+    const MAX_IN_FLIGHT: usize = 4096;
+
     pub async fn run(mut self) {
+        let semaphore = Arc::new(Semaphore::new(Self::MAX_IN_FLIGHT));
+
         while let Some(box_fn) = self.worker_rx.recv().await {
-            (box_fn)(self.meta_node.clone()).await;
+            let permit = semaphore
+                .clone()
+                .acquire_owned()
+                .await
+                .expect("semaphore closed");
+
+            let meta_node = self.meta_node.clone();
+            RT::spawn(
+                async move {
+                    (box_fn)(meta_node).await;
+                    drop(permit);
+                },
+                Some("meta-request".to_string()),
+            );
         }
 
         info!(


### PR DESCRIPTION

## Changelog

##### chore: Bump Ver: 260312.7.0

##### refactor: parallelize MetaWorker request processing
MetaWorker::run previously awaited each request serially, meaning
every read had to wait behind slow writes (and vice versa) in the
single-consumer queue. During snapshot/compaction, a single slow
write holding a WriterPermit for 30-40ms would block all queued
reads, inflating read p50 to match write p50.

Spawn each incoming request as an independent task via RT::spawn
so reads and writes execute concurrently. Writes still serialize
internally through raft consensus, but reads no longer wait behind
them.

Benchmark (4 writers, 8 readers, 30s, 4KB values):

  Before: read p50 29ms, write p50 37ms,   read 7.3k ops/s
  After:  read p50 226us, write p50 9.9ms, read 940k ops/s


##### feat: add MetaWorker contention benchmark
End-to-end benchmark that measures the impact of `MetaWorker::run`
serial request processing on read/write latency. The benchmark starts
a single-node meta-service via `MetaSrvTestContext`, warms up with
500 keys (4 KB each), then hammers it with 4 concurrent gRPC writers
and 8 concurrent gRPC readers for 30 seconds. Snapshots are triggered
every 100 logs to reproduce the production scenario where compaction
contends with apply.

Baseline results confirm the serialization bottleneck: read p50
(33.9 ms) tracks write p50 (36.0 ms) almost identically, because
every request — including reads that never touch raft — must wait
behind slow writes in the single-threaded `MetaWorker::run` loop.
After parallelizing `MetaWorker::run`, reads should decouple from
writes and drop by an order of magnitude.

Example:

    cargo run --release --bin meta_worker_contention

      Writes:   3186 ops  |  p50  36.00ms  p90  38.10ms  p99  46.40ms  p999 689.48ms  max 942.52ms
       Reads:   6992 ops  |  p50  33.93ms  p90  39.10ms  p99  47.92ms  p999 680.00ms  max 942.40ms


##### chore: Bump Ver: 260312.6.0

---

- Improvement
