### PR TITLE
fix: filter non-voter leader ids in MetaNode::get_leader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ databend-meta-version = { path = "crates/common/version" }
 
 # External dependencies from databendlabs forks
 base2histogram = "0.2.3"
-databend-base = "0.3.0"
+databend-base = "0.4.0"
 map-api = "0.4.2"
 openraft = { version = "=0.10.0-alpha.18", features = ["serde", "tracing-log"] }
 sled = { version = "0.34", default-features = false }
@@ -157,7 +157,7 @@ rpath = true
 
 [patch.crates-io]
 async-backtrace = { git = "https://github.com/datafuse-extras/async-backtrace.git", rev = "dea4553" }
-databend-base = { git = "https://github.com/databendlabs/databend-base", tag = "v0.3.0" }
+databend-base = { git = "https://github.com/databendlabs/databend-base", tag = "v0.4.0" }
 map-api = { git = "https://github.com/databendlabs/map-api", tag = "v0.4.2" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1" }
 state-machine-api = { git = "https://github.com/databendlabs/state-machine-api.git", tag = "v0.3.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ databend-meta-version = { path = "crates/common/version" }
 base2histogram = "0.2.3"
 databend-base = "0.3.0"
 map-api = "0.4.2"
-openraft = { version = "=0.10.0-alpha.17", features = ["serde", "tracing-log"] }
+openraft = { version = "=0.10.0-alpha.18", features = ["serde", "tracing-log"] }
 sled = { version = "0.34", default-features = false }
 state-machine-api = "0.3.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "260312.7.0"
+version = "260312.8.0"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false

--- a/crates/client/types/src/raft_types.rs
+++ b/crates/client/types/src/raft_types.rs
@@ -120,6 +120,9 @@ impl RaftTypeConfig for TypeConfig {
     type Responder<T>
         = OneshotResponder<Self, T>
     where T: openraft::OptionalSend + 'static;
+    type Batch<T>
+        = openraft::impls::InlineBatch<T>
+    where T: openraft::OptionalSend + 'static;
     type ErrorSource = anyerror::AnyError;
 }
 

--- a/crates/common/version/src/grpc_changelog.rs
+++ b/crates/common/version/src/grpc_changelog.rs
@@ -106,6 +106,12 @@ pub fn grpc_changelog() -> BTreeMap<Version, GrpcVersionCompat> {
         min_server: ver(260217, 0, 0),
     });
 
+    // 260312.8.0: no compatibility change
+    m.insert(ver(260312, 8, 0), GrpcVersionCompat {
+        min_client: ver(1, 2, 676),
+        min_server: ver(260217, 0, 0),
+    });
+
     m
 }
 

--- a/crates/common/version/src/lib.rs
+++ b/crates/common/version/src/lib.rs
@@ -140,17 +140,17 @@ mod tests {
 
     #[test]
     fn test_version_string() {
-        assert_eq!(version_str(), "260312.7.0");
+        assert_eq!(version_str(), "260312.8.0");
     }
 
     #[test]
     fn test_semver_components() {
-        assert_eq!(semver_tuple(version()), (260312, 7, 0));
+        assert_eq!(semver_tuple(version()), (260312, 8, 0));
     }
 
     #[test]
     fn test_semver_display() {
-        assert_eq!(version().to_semver().to_string(), "260312.7.0");
+        assert_eq!(version().to_semver().to_string(), "260312.8.0");
     }
 
     #[test]

--- a/crates/server/service/src/meta_node/meta_node.rs
+++ b/crates/server/service/src/meta_node/meta_node.rs
@@ -1447,6 +1447,14 @@ impl<SP: SpawnApi> MetaNode<SP> {
 
     /// Try to get the leader from the latest metrics of the local raft node.
     /// If leader is absent, wait for an metrics update in which a leader is set.
+    ///
+    /// databend-meta requires every node (including the leader) to be in the
+    /// effective membership. openraft 0.10-alpha.18 changed
+    /// `RaftMetrics::current_leader` to expose the raw vote leader id without
+    /// validating it against the membership, which is valid in openraft's
+    /// model but violates our invariant. Treat a leader that is not a voter
+    /// as "no known leader" so the node can self-elect (single-voter
+    /// clusters) or wait for a real leader to emerge.
     #[fastrace::trace]
     pub async fn get_leader(&self) -> Result<Option<NodeId>, RecvError> {
         let mut rx = self.raft.metrics();
@@ -1454,7 +1462,13 @@ impl<SP: SpawnApi> MetaNode<SP> {
         let mut expire_at: Option<Instant> = None;
 
         loop {
-            if let Some(l) = rx.borrow_watched().current_leader {
+            let leader_id = {
+                let m = rx.borrow_watched();
+                m.current_leader
+                    .filter(|id| m.membership_config.voter_ids().any(|v| &v == id))
+            };
+
+            if let Some(l) = leader_id {
                 return Ok(Some(l));
             }
 

--- a/crates/server/types/src/raft_types.rs
+++ b/crates/server/types/src/raft_types.rs
@@ -48,6 +48,9 @@ impl RaftTypeConfig for TypeConfig {
     type Responder<T>
         = OneshotResponder<Self, T>
     where T: openraft::OptionalSend + 'static;
+    type Batch<T>
+        = openraft::impls::InlineBatch<T>
+    where T: openraft::OptionalSend + 'static;
     type ErrorSource = anyerror::AnyError;
 }
 


### PR DESCRIPTION

## Changelog

##### fix: filter non-voter leader ids in MetaNode::get_leader
databend-meta's invariant is that every node, including the leader,
must be in the effective membership. openraft 0.10-alpha.18 changed
RaftMetrics::current_leader to expose the raw vote leader id without
validating it against membership -- valid in openraft's model but
violates our invariant.

Treat a non-voter current_leader as "no known leader" so the existing
wait loop lets the node self-elect (single-voter case) or wait for a
real leader. Restores alpha.17 semantics at our layer.

Fixes test_raft_service_install_snapshot_v004 after the alpha.18 bump.


##### chore: upgrade databend-base from 0.3.0 to 0.4.0
databend-base 0.4.0 replaces the jwt-simple dep with jsonwebtoken,
removing the vulnerable `rsa 0.9.x` crate (RUSTSEC-2023-0071, Marvin
Attack) from the dependency tree.

`grpc_service` only passes the JWT error through `Display` formatting
(`e.to_string()` / `{}`), so the upstream error-type change from
`jwt_simple::Error` to `jsonwebtoken::errors::Error` is source-compatible.


##### chore: upgrade openraft from alpha.17 to alpha.18
openraft alpha.18 adds a new required associated type `Batch<T>` to
`RaftTypeConfig`. Implement it on both server and client `TypeConfig`
using the default `openraft::impls::InlineBatch<T>`.


##### chore: Bump Ver: 260312.8.0

---

- Bug Fix
