### PR TITLE
feat: re-export openraft and openraft-rt from server crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "260312.8.0"
+version = "260312.9.0"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false

--- a/crates/common/version/src/grpc_changelog.rs
+++ b/crates/common/version/src/grpc_changelog.rs
@@ -112,6 +112,12 @@ pub fn grpc_changelog() -> BTreeMap<Version, GrpcVersionCompat> {
         min_server: ver(260217, 0, 0),
     });
 
+    // 260312.9.0: no compatibility change
+    m.insert(ver(260312, 9, 0), GrpcVersionCompat {
+        min_client: ver(1, 2, 676),
+        min_server: ver(260217, 0, 0),
+    });
+
     m
 }
 

--- a/crates/common/version/src/lib.rs
+++ b/crates/common/version/src/lib.rs
@@ -140,17 +140,17 @@ mod tests {
 
     #[test]
     fn test_version_string() {
-        assert_eq!(version_str(), "260312.8.0");
+        assert_eq!(version_str(), "260312.9.0");
     }
 
     #[test]
     fn test_semver_components() {
-        assert_eq!(semver_tuple(version()), (260312, 8, 0));
+        assert_eq!(semver_tuple(version()), (260312, 9, 0));
     }
 
     #[test]
     fn test_semver_display() {
-        assert_eq!(version().to_semver().to_string(), "260312.8.0");
+        assert_eq!(version().to_semver().to_string(), "260312.9.0");
     }
 
     #[test]

--- a/crates/server/service/src/lib.rs
+++ b/crates/server/service/src/lib.rs
@@ -29,6 +29,7 @@ pub extern crate databend_meta_runtime_api as runtime_api;
 pub extern crate databend_meta_sled_store as sled_store;
 pub extern crate databend_meta_types as types;
 pub extern crate databend_meta_version as version;
+pub extern crate openraft;
 
 pub(crate) mod analysis;
 pub mod api;


### PR DESCRIPTION

## Changelog

##### feat: re-export openraft and openraft-rt from server crate
Downstream consumers (databend) can import openraft via
`databend_meta::openraft::*` and `databend_meta::openraft_rt::*`
instead of depending on openraft/openraft-rt directly. This keeps
the openraft version in lockstep with the server crate and removes
a category of version-skew bugs between consumers and the server.

---


