### PR TITLE
refactor: switch from RaftNetworkV2 to split sub-trait impls

### DIFF
--- a/crates/server/service/src/network.rs
+++ b/crates/server/service/src/network.rs
@@ -43,6 +43,7 @@ use databend_meta_types::raft_types::RaftError;
 use databend_meta_types::raft_types::Snapshot;
 use databend_meta_types::raft_types::SnapshotResponse;
 use databend_meta_types::raft_types::StorageError;
+use databend_meta_types::raft_types::StreamAppendResult;
 use databend_meta_types::raft_types::StreamingError;
 use databend_meta_types::raft_types::TransferLeaderRequest;
 use databend_meta_types::raft_types::TypeConfig;
@@ -52,6 +53,7 @@ use databend_meta_types::raft_types::VoteRequest;
 use databend_meta_types::raft_types::VoteResponse;
 use fastrace::func_name;
 use futures::FutureExt;
+use futures::Stream;
 use futures::StreamExt;
 use futures::TryStreamExt;
 use log::debug;
@@ -60,9 +62,17 @@ use log::info;
 use log::warn;
 use openraft::MessageSummary;
 use openraft::RaftNetworkFactory;
+use openraft::base::BoxFuture;
+use openraft::base::BoxStream;
 use openraft::error::ReplicationClosed;
+use openraft::network::NetAppend;
+use openraft::network::NetBackoff;
+use openraft::network::NetSnapshot;
+use openraft::network::NetStreamAppend;
+use openraft::network::NetTransferLeader;
+use openraft::network::NetVote;
 use openraft::network::RPCOption;
-use openraft::network::v2::RaftNetworkV2;
+use openraft::network::stream_append_sequential;
 use seq_marked::SeqData;
 use seq_marked::SeqV;
 use state_machine_api::MetaValue;
@@ -723,7 +733,19 @@ impl<SP: SpawnApi> Network<SP> {
     }
 }
 
-impl<SP: SpawnApi> RaftNetworkV2<TypeConfig> for Network<SP> {
+// === Sub-trait impls ===
+//
+// We implement openraft's split network sub-traits directly instead of the
+// umbrella `RaftNetworkV2`. This is required because `NetStreamAppend` is
+// blanket-implemented for any `RaftNetworkV2` impl, so to provide a custom
+// `stream_append` we cannot also impl `RaftNetworkV2`.
+
+/// Unary AppendEntries via the legacy single-RPC endpoint.
+///
+/// Used by [`stream_append_sequential`] in the [`NetStreamAppend`] impl below
+/// as the per-request adapter. A subsequent commit will add an `AppendV001`
+/// fast path on top of this.
+impl<SP: SpawnApi> NetAppend<TypeConfig> for Network<SP> {
     /// Send AppendEntries RPC with automatic payload size management.
     ///
     /// If the payload exceeds gRPC size limit, reduces entry count and retries.
@@ -816,7 +838,27 @@ impl<SP: SpawnApi> RaftNetworkV2<TypeConfig> for Network<SP> {
             }
         }
     }
+}
 
+/// Streaming AppendEntries.
+///
+/// Adapts the unary [`NetAppend::append_entries`] into a stream by delegating
+/// to openraft's [`stream_append_sequential`] helper, which sends one request
+/// at a time and yields a stream of [`StreamAppendResult`]s.
+impl<SP: SpawnApi> NetStreamAppend<TypeConfig> for Network<SP> {
+    fn stream_append<'s, S>(
+        &'s mut self,
+        input: S,
+        option: RPCOption,
+    ) -> BoxFuture<'s, Result<BoxStream<'s, Result<StreamAppendResult, RPCError>>, RPCError>>
+    where
+        S: Stream<Item = AppendEntriesRequest> + Send + Unpin + 'static,
+    {
+        stream_append_sequential(self, input, option)
+    }
+}
+
+impl<SP: SpawnApi> NetSnapshot<TypeConfig> for Network<SP> {
     /// Send snapshot to target node. Currently uses V004 streaming protocol.
     /// TODO: Add version negotiation to choose between V003/V004 based on target capabilities.
     #[logcall::logcall(err = "error", input = "")]
@@ -889,7 +931,9 @@ impl<SP: SpawnApi> RaftNetworkV2<TypeConfig> for Network<SP> {
             Err(err)
         }
     }
+}
 
+impl<SP: SpawnApi> NetVote<TypeConfig> for Network<SP> {
     #[logcall::logcall(err = "debug")]
     #[fastrace::trace]
     async fn vote(
@@ -954,7 +998,9 @@ impl<SP: SpawnApi> RaftNetworkV2<TypeConfig> for Network<SP> {
 
         self.parse_grpc_resp::<_, openraft::error::Infallible>(grpc_res)
     }
+}
 
+impl<SP: SpawnApi> NetTransferLeader<TypeConfig> for Network<SP> {
     async fn transfer_leader(
         &mut self,
         req: TransferLeaderRequest,
@@ -991,7 +1037,9 @@ impl<SP: SpawnApi> RaftNetworkV2<TypeConfig> for Network<SP> {
         grpc_res.map_err(|e| RPCError::Unreachable(self.status_to_unreachable(e)))?;
         Ok(())
     }
+}
 
+impl<SP: SpawnApi> NetBackoff<TypeConfig> for Network<SP> {
     /// When a `Unreachable` error is returned from the `Network`,
     /// Openraft will call this method to build a backoff instance.
     fn backoff(&self) -> openraft::network::Backoff {

--- a/crates/tests/raft-protocol-compat/bin-v260205.4.0/Cargo.toml
+++ b/crates/tests/raft-protocol-compat/bin-v260205.4.0/Cargo.toml
@@ -20,11 +20,24 @@ databend-meta-types = { git = "https://github.com/databendlabs/databend-meta.git
 env_logger = "0.11"
 log = "0.4"
 openraft = "=0.10.0-alpha.17"
+# Pin transitive deps that drifted past breaking patch-version releases:
+#   - openraft-rt / openraft-rt-tokio: alpha.18 links rand 0.10 / rand_core 0.10,
+#     causing a `Rng`/`RngCore` trait mismatch when openraft alpha.17 calls
+#     `random_range` on `<RT as AsyncRuntime>::ThreadLocalRng`.
+#   - rotbl: 0.2.10 removed `BlockCacheConfig::with_max_items`, which the
+#     pinned `databend-meta v260205.4.0` source still calls.
+openraft-rt = "=0.10.0-alpha.17"
+openraft-rt-tokio = "=0.10.0-alpha.17"
+rotbl = "=0.2.9"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1.35", features = ["full"] }
 tokio-stream = { version = "0.1.11", features = ["net"] }
 tonic = "0.13"
+
+[package.metadata.cargo-machete]
+# These are version-pin-only deps that constrain the resolver; not directly used.
+ignored = ["openraft-rt", "openraft-rt-tokio", "rotbl"]
 
 [patch.crates-io]
 async-backtrace = { git = "https://github.com/datafuse-extras/async-backtrace.git", rev = "dea4553" }


### PR DESCRIPTION

## Changelog

##### refactor: switch from RaftNetworkV2 to split sub-trait impls
Use the latest openraft network API (NetAppend / NetStreamAppend /
NetVote / NetSnapshot / NetTransferLeader / NetBackoff) instead of the
umbrella RaftNetworkV2 trait. This is a structural prerequisite for
adding native AppendV001 streaming on top of NetStreamAppend in a
follow-up commit.

For now NetStreamAppend delegates to openraft stream_append_sequential,
which adapts the unary NetAppend::append_entries (legacy AppendEntries
RPC) into a stream. Method bodies for vote / full_snapshot /
transfer_leader / backoff are unchanged from the original umbrella
impl; only the surrounding impl trait headers change.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


##### chore: pin transitive deps in raft protocol compat-old binary
The compat-old binary pins openraft = "=0.10.0-alpha.17", but Cargo
pre-release semver lets transitive openraft-rt / openraft-rt-tokio
drift to alpha.18, which links a different rand_core major version and
breaks trait coherence at openraft alpha.17 call to random_range on
<RT as AsyncRuntime>::ThreadLocalRng. Same shape of issue for rotbl
0.2.10 dropping BlockCacheConfig::with_max_items that the pinned
databend-meta v260205.4.0 source still calls.

Pin all three to exact versions and add a cargo-machete ignore for the
two pin-only deps that don't appear in source.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

- Improvement
