### PR TITLE
chore: Bump Ver: 260428.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "260428.0.0"
+version = "260428.1.0"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ seq-marked = { version = "0.3.5", features = ["seq-marked-serde", "seq-marked-bi
 serde = { version = "1.0.164", features = ["derive", "rc"] }
 serde_json = { version = "1.0.85", default-features = false, features = ["preserve_order", "unbounded_depth"] }
 stream-more = "0.1.3"
-structkey = "0.1.0"
+structkey = "0.1.1"
 strum = "0.24.1"
 strum_macros = "0.24"
 tempfile = "3.4.0"

--- a/crates/common/version/src/grpc_changelog.rs
+++ b/crates/common/version/src/grpc_changelog.rs
@@ -132,6 +132,12 @@ pub fn grpc_changelog() -> BTreeMap<Version, GrpcVersionCompat> {
         min_server: ver(260217, 0, 0),
     });
 
+    // 260428.1.0: no compatibility change
+    m.insert(ver(260428, 1, 0), GrpcVersionCompat {
+        min_client: ver(1, 2, 676),
+        min_server: ver(260217, 0, 0),
+    });
+
     m
 }
 

--- a/crates/common/version/src/lib.rs
+++ b/crates/common/version/src/lib.rs
@@ -140,17 +140,17 @@ mod tests {
 
     #[test]
     fn test_version_string() {
-        assert_eq!(version_str(), "260428.0.0");
+        assert_eq!(version_str(), "260428.1.0");
     }
 
     #[test]
     fn test_semver_components() {
-        assert_eq!(semver_tuple(version()), (260428, 0, 0));
+        assert_eq!(semver_tuple(version()), (260428, 1, 0));
     }
 
     #[test]
     fn test_semver_display() {
-        assert_eq!(version().to_semver().to_string(), "260428.0.0");
+        assert_eq!(version().to_semver().to_string(), "260428.1.0");
     }
 
     #[test]

--- a/crates/tests/raft-protocol-compat/bin-current/Cargo.lock
+++ b/crates/tests/raft-protocol-compat/bin-current/Cargo.lock
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta"
-version = "260428.0.0"
+version = "260428.1.0"
 dependencies = [
  "anyerror",
  "anyhow",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-base"
-version = "260428.0.0"
+version = "260428.1.0"
 dependencies = [
  "anyerror",
  "deepsize",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client"
-version = "260428.0.0"
+version = "260428.1.0"
 dependencies = [
  "anyerror",
  "arrow-flight",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client-types"
-version = "260428.0.0"
+version = "260428.1.0"
 dependencies = [
  "anyerror",
  "databend-meta-proto",
@@ -1025,23 +1025,21 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi"
-version = "260428.0.0"
+version = "260428.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "databend-base",
  "databend-meta-client-types",
  "display-more 0.2.6",
  "futures-util",
  "log",
  "serde",
  "structkey",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "databend-meta-kvapi-test-suite"
-version = "260428.0.0"
+version = "260428.1.0"
 dependencies = [
  "anyhow",
  "databend-meta-client-types",
@@ -1056,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-proto"
-version = "260428.0.0"
+version = "260428.1.0"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -1078,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-raft-store"
-version = "260428.0.0"
+version = "260428.1.0"
 dependencies = [
  "anyerror",
  "anyhow",
@@ -1118,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-runtime-api"
-version = "260428.0.0"
+version = "260428.1.0"
 dependencies = [
  "env_logger",
  "hickory-resolver",
@@ -1130,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-sled-store"
-version = "260428.0.0"
+version = "260428.1.0"
 dependencies = [
  "anyerror",
  "byteorder",
@@ -1147,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-types"
-version = "260428.0.0"
+version = "260428.1.0"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -1174,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-version"
-version = "260428.0.0"
+version = "260428.1.0"
 dependencies = [
  "semver",
 ]
@@ -3664,9 +3662,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "structkey"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934b5adefea98275ded897bd93527bb68f84466adefb0bfaa5764816e0cbee92"
+checksum = "c567f1a469136e44fd0d9cba05a1d84bf5e6b4ec9cd7b247a35112c70ec8d071"
 dependencies = [
  "structkey-derive",
  "thiserror 2.0.18",
@@ -3674,9 +3672,9 @@ dependencies = [
 
 [[package]]
 name = "structkey-derive"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "920e7280c67d538a8108b97dd869446e780fc7ca605fa2a61005fef0d743f4b7"
+checksum = "94154ada6f86e5fb44b788faf8581dcac9a1811c40ba8daaed7f3a8972c4b2a5"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",


### PR DESCRIPTION

## Changelog

##### chore: Bump Ver: 260428.1.0

##### chore: bump structkey to 0.1.1
# Summary

Pick up the structkey 0.1.1 patch release.

# Details

0.1.1 carries two fixes that strengthen the `#[derive(Codec)]`
contract without changing the wire format:

- Compile-time error for enums whose effective discriminants collide
  (typically a `#[codec(rename = "...")]` aliasing another variant's
  default), preventing a silent decode-as-first-match bug.
- `Builder` no longer fuses an empty-string first segment with the
  next segment; round-trips of structs whose first field encodes to
  `""` are now lossless.

No source change in this crate; the bump is purely a dep version
update.

---


