### PR TITLE
chore: Bump Ver: 260428.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ pretty_assertions = "1.3.0"
 prometheus-client = "0.22"
 prost = "0.13"
 prost-build = "0.13"
-raft-log = "0.3.0"
+raft-log = "0.4.0"
 rand = { version = "0.8.5", features = ["small_rng", "serde1"] }
 regex = "1.8.1"
 rmp-serde = "1.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "260428.2.0"
+version = "260428.3.0"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false

--- a/crates/common/version/src/grpc_changelog.rs
+++ b/crates/common/version/src/grpc_changelog.rs
@@ -144,6 +144,12 @@ pub fn grpc_changelog() -> BTreeMap<Version, GrpcVersionCompat> {
         min_server: ver(260217, 0, 0),
     });
 
+    // 260428.3.0: no compatibility change
+    m.insert(ver(260428, 3, 0), GrpcVersionCompat {
+        min_client: ver(1, 2, 676),
+        min_server: ver(260217, 0, 0),
+    });
+
     m
 }
 

--- a/crates/common/version/src/lib.rs
+++ b/crates/common/version/src/lib.rs
@@ -140,17 +140,17 @@ mod tests {
 
     #[test]
     fn test_version_string() {
-        assert_eq!(version_str(), "260428.2.0");
+        assert_eq!(version_str(), "260428.3.0");
     }
 
     #[test]
     fn test_semver_components() {
-        assert_eq!(semver_tuple(version()), (260428, 2, 0));
+        assert_eq!(semver_tuple(version()), (260428, 3, 0));
     }
 
     #[test]
     fn test_semver_display() {
-        assert_eq!(version().to_semver().to_string(), "260428.2.0");
+        assert_eq!(version().to_semver().to_string(), "260428.3.0");
     }
 
     #[test]

--- a/crates/server/raft-store/src/raft_log_v004/util.rs
+++ b/crates/server/raft-store/src/raft_log_v004/util.rs
@@ -25,7 +25,7 @@ pub async fn blocking_flush(rl: &mut RaftLogV004) -> Result<(), io::Error> {
     let (tx, rx) = oneshot::channel();
     let callback = Callback::new_oneshot(tx, IODesc::unknown("blocking_flush(RaftLogV004)"));
 
-    rl.flush(Some(callback))?;
+    rl.flush(true, Some(callback))?;
     rx.await
         .map_err(|_e| io::Error::other("Failed to receive flush completion"))??;
     Ok(())

--- a/crates/server/service/src/store/meta_raft_log/impl_raft_log_storage.rs
+++ b/crates/server/service/src/store/meta_raft_log/impl_raft_log_storage.rs
@@ -162,7 +162,10 @@ impl RaftLogStorage<TypeConfig> for MetaRaftLog {
             let mut log = self.write().await;
 
             log.save_vote(Cw(*vote))?;
-            log.flush(Some(raft_log_v004::Callback::new_oneshot(tx, io.clone())))?;
+            log.flush(
+                true,
+                Some(raft_log_v004::Callback::new_oneshot(tx, io.clone())),
+            )?;
         }
 
         rx.await.map_err(io::Error::other)??;
@@ -186,6 +189,13 @@ impl RaftLogStorage<TypeConfig> for MetaRaftLog {
         {
             let mut log = self.write().await;
             log.commit(Cw(committed))?;
+            // Push the commit record to the worker without forcing an
+            // fsync. The committed log id is best-effort durability:
+            // worth getting into the OS page cache (so a process crash
+            // preserves it via kernel writeback) but not worth a real
+            // fsync per commit advance. The next `append`'s sync flush
+            // carries this record to disk along with its own batch.
+            log.flush(false, None)?;
         }
 
         debug!(
@@ -227,10 +237,13 @@ impl RaftLogStorage<TypeConfig> for MetaRaftLog {
 
         debug!("{}", io.ok_submit());
 
-        log.flush(Some(raft_log_v004::Callback::new_io_flushed(
-            callback,
-            io.clone(),
-        )))?;
+        log.flush(
+            true,
+            Some(raft_log_v004::Callback::new_io_flushed(
+                callback,
+                io.clone(),
+            )),
+        )?;
 
         info!("{}", io.ok_submit_flush());
 

--- a/crates/tests/raft-protocol-compat/bin-current/Cargo.lock
+++ b/crates/tests/raft-protocol-compat/bin-current/Cargo.lock
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta"
-version = "260428.2.0"
+version = "260428.3.0"
 dependencies = [
  "anyerror",
  "anyhow",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-base"
-version = "260428.2.0"
+version = "260428.3.0"
 dependencies = [
  "anyerror",
  "deepsize",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client"
-version = "260428.2.0"
+version = "260428.3.0"
 dependencies = [
  "anyerror",
  "arrow-flight",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client-types"
-version = "260428.2.0"
+version = "260428.3.0"
 dependencies = [
  "anyerror",
  "databend-meta-proto",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi"
-version = "260428.2.0"
+version = "260428.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi-test-suite"
-version = "260428.2.0"
+version = "260428.3.0"
 dependencies = [
  "anyhow",
  "databend-meta-client-types",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-proto"
-version = "260428.2.0"
+version = "260428.3.0"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-raft-store"
-version = "260428.2.0"
+version = "260428.3.0"
 dependencies = [
  "anyerror",
  "anyhow",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-runtime-api"
-version = "260428.2.0"
+version = "260428.3.0"
 dependencies = [
  "env_logger",
  "hickory-resolver",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-sled-store"
-version = "260428.2.0"
+version = "260428.3.0"
 dependencies = [
  "anyerror",
  "byteorder",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-types"
-version = "260428.2.0"
+version = "260428.3.0"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-version"
-version = "260428.2.0"
+version = "260428.3.0"
 dependencies = [
  "semver",
 ]
@@ -3012,9 +3012,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "raft-log"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c273df82ff5ef584c3b38ca603942b5c2b0b786f7bad70881c6d85b485f5778b"
+checksum = "9b13c64d8e24f1791caae6ec10f1f3e90299ad0e0af7d006fda7db4382178d2e"
 dependencies = [
  "byteorder",
  "codeq",


### PR DESCRIPTION

## Changelog

##### chore: Bump Ver: 260428.3.0

##### change: bump raft-log to 0.4.0 and adopt `flush(sync, _)`
# Summary

`raft-log` 0.4.0 changes the trait signature from `flush(callback)` to
`flush(sync, callback)`. Existing callers all want the previous fsync
semantics, so they pass `true`. `save_committed` switches to `false` to
land the commit record in the OS page cache without paying for an
fsync.

# Details

The previous fix for the AppendEntries write-tail regression
(`v260428.2.0`) removed the `log.flush(None)` from `save_committed`
because that call still queued a real fsync per commit advance on
raft-log 0.3.0. Removing it left the committed record in the
in-process pending buffer until the next `append`'s flush, which is
correct but weaker than necessary: a clean process crash before the
next append loses the record entirely.

raft-log 0.4.0 adds the no-sync write path that `save_committed` was
missing. `flush(false, None)` hands the pending bytes to the worker —
the worker calls `write_all` on the file (so the bytes reach the
kernel page cache and survive a process crash via writeback) and skips
the `fsync`. The next `append` does `flush(true, _)`, which the worker
batches with any pending no-sync writes and fsyncs the whole batch in
one syscall. So the durability ladder for `save_committed` is:

  in-process buffer  <  OS page cache  <  fsynced

and we now sit on the middle rung instead of the bottom one, at no
incremental fsync cost.

---


