### PR TITLE
perf: drop the no-sync flush from save_committed

### DIFF
--- a/crates/server/service/src/store/meta_raft_log/impl_raft_log_storage.rs
+++ b/crates/server/service/src/store/meta_raft_log/impl_raft_log_storage.rs
@@ -189,19 +189,17 @@ impl RaftLogStorage<TypeConfig> for MetaRaftLog {
         {
             let mut log = self.write().await;
             log.commit(Cw(committed))?;
-            // Push the commit record to the worker without forcing an
-            // fsync. The committed log id is best-effort durability:
-            // worth getting into the OS page cache (so a process crash
-            // preserves it via kernel writeback) but not worth a real
-            // fsync per commit advance. The next `append`'s sync flush
-            // carries this record to disk along with its own batch.
-            log.flush(false, None)?;
         }
 
-        debug!(
-            "{}; flush without waiting: best-effort persist committed log id",
-            io.ok_submit()
-        );
+        // commit() updates the in-memory `RaftLogState::committed`, which
+        // is what `read_committed()` returns, so callers see the new
+        // committed value immediately. The Commit record sits in
+        // `pending_data` until the next `append` flushes it along with
+        // its own batch — no separate worker request needed. Persisting
+        // the committed id is optional per the openraft contract; if a
+        // crash drops the record before the next append, startup just
+        // re-applies a few entries to the state machine.
+        debug!("{}; persist deferred to next append", io.ok_submit());
         Ok(())
     }
 


### PR DESCRIPTION

## Changelog

##### perf: drop the no-sync flush from save_committed
# Summary

`save_committed` now just calls `commit()` and returns. The Commit
record left in `pending_data` rides along with the next `append`'s
flush at no extra cost — no separate worker request per commit
advance.

# Details

The previous version of this commit added `flush(false, None)` after
`commit()` to push the Commit record into the OS page cache so it
survived a process crash via kernel writeback. That gives one extra
worker `write_all` syscall per commit advance and was visible as a
small bump in the slow-IO counter on the follower in the mixed-version
benchmark (run 04: +15 vs run 03: +2).

The extra durability turns out to be unnecessary. `commit()` updates
the in-memory `RaftLogState::committed` synchronously, so
`read_committed()` and openraft's in-process state see the new value
immediately. The Commit record's only job is to make that value
recoverable on restart, and openraft's contract for `save_committed`
explicitly classifies it as best-effort: "persisting the commit index
is optional in Raft, it can optimize state machine replay during node
restart by avoiding re-application of already committed entries."

So if a process crashes after a commit advance but before the next
`append`, startup just re-applies a few entries to the state machine —
slower startup in a narrow window, not a correctness problem. Every
real commit advance in steady-state traffic is followed by an `append`
within microseconds, which flushes the pending Commit record as part
of its own batch.

raft-log 0.4.0's `flush(sync, callback)` API stays in use for
`save_vote` and `append`; this commit just stops calling it for the
case where it does not earn its keep.

---


