### PR TITLE
change: replace AppendV001 with AppendV002 carrying full Cmd schema

### DIFF
--- a/crates/common/proto/proto/log_entry.proto
+++ b/crates/common/proto/proto/log_entry.proto
@@ -16,7 +16,7 @@
 //
 // These messages are the wire format for `Cmd` variants carried inside
 // `LogEntry` (defined in meta.proto).  They are used by the typed
-// `AppendV001` streaming RPC to transport log entries between raft peers.
+// `AppendV002` streaming RPC to transport log entries between raft peers.
 //
 // Native Rust counterparts live in `crate::log_entry` and `crate::cmd`;
 // conversions are in `crate::log_entry::convert`.

--- a/crates/common/proto/proto/meta.proto
+++ b/crates/common/proto/proto/meta.proto
@@ -469,7 +469,7 @@ service RaftService {
 
   rpc VoteV001(VoteRequest) returns (VoteResponse);
 
-  rpc AppendV001(stream AppendRequest) returns (stream AppendResponse);
+  rpc AppendV002(stream AppendRequest) returns (stream AppendResponse);
 
   rpc TransferLeader(TransferLeaderRequest) returns (Empty);
 }

--- a/crates/common/version/src/grpc_changelog.rs
+++ b/crates/common/version/src/grpc_changelog.rs
@@ -125,8 +125,8 @@ pub fn grpc_changelog() -> BTreeMap<Version, GrpcVersionCompat> {
     });
 
     // 260428.0.0: no grpc compatibility change.
-    // Raft-side `AppendV001` capability extended to carry `Cmd::UpsertKV` and
-    // `Cmd::Transaction`; client wiring lands later, so grpc compat is unchanged.
+    // Raft-side `AppendV002` RPC introduced (replacing the never-shipped
+    // `AppendV001`); grpc client/server compat is unchanged.
     m.insert(ver(260428, 0, 0), GrpcVersionCompat {
         min_client: ver(1, 2, 676),
         min_server: ver(260217, 0, 0),

--- a/crates/common/version/src/raft_feat.rs
+++ b/crates/common/version/src/raft_feat.rs
@@ -32,13 +32,13 @@ pub enum RaftFeature {
     VoteV001,
 
     /// Typed streaming append RPC with `LogEntry` entries.
-    AppendV001,
-
-    /// `AppendV001` carries `Cmd::UpsertKV` entries (legacy variant).
-    AppendV001UpsertKv,
-
-    /// `AppendV001` carries `Cmd::Transaction` entries (legacy variant).
-    AppendV001Transaction,
+    ///
+    /// Carries the full `Cmd` schema (including the legacy `UpsertKV` and
+    /// `Transaction` variants) from the start. Replaces the never-shipped
+    /// `AppendV001`, which exposed a streaming endpoint without the legacy
+    /// variants and could not be safely used by any client (older servers
+    /// silently dropped unknown oneof tags rather than rejecting them).
+    AppendV002,
 
     /// Binary chunk snapshot transfer.
     SnapshotV003,
@@ -57,9 +57,7 @@ impl RaftFeature {
             RaftFeature::AppendEntries,
             RaftFeature::Vote,
             RaftFeature::VoteV001,
-            RaftFeature::AppendV001,
-            RaftFeature::AppendV001UpsertKv,
-            RaftFeature::AppendV001Transaction,
+            RaftFeature::AppendV002,
             RaftFeature::SnapshotV003,
             RaftFeature::SnapshotV004,
             RaftFeature::TransferLeader,
@@ -72,9 +70,7 @@ impl RaftFeature {
             RaftFeature::AppendEntries => "raft/append_entries",
             RaftFeature::Vote => "raft/vote",
             RaftFeature::VoteV001 => "raft/vote_v001",
-            RaftFeature::AppendV001 => "raft/append_v001",
-            RaftFeature::AppendV001UpsertKv => "raft/append_v001/upsert_kv",
-            RaftFeature::AppendV001Transaction => "raft/append_v001/transaction",
+            RaftFeature::AppendV002 => "raft/append_v002",
             RaftFeature::SnapshotV003 => "raft/snapshot_v003",
             RaftFeature::SnapshotV004 => "raft/snapshot_v004",
             RaftFeature::TransferLeader => "raft/transfer_leader",

--- a/crates/common/version/src/raft_spec.rs
+++ b/crates/common/version/src/raft_spec.rs
@@ -88,26 +88,24 @@ impl RaftSpec {
             // if peer doesn't support it.
             add_optional(&mut cli, F::SnapshotV004, ver(1, 2, 818));
 
-            // 2026-02-26: since 260217.0.0 (this repo):
-            // 🖥 raft server: accept streaming AppendV001 RPC
-            add(&mut srv, F::AppendV001, ver(260217, 0, 0));
-            // 📡 raft client: optionally used since 260217.0.0; falls back to
-            // legacy AppendEntries if peer doesn't support it.
-            add_optional(&mut cli, F::AppendV001, ver(260217, 0, 0));
-
             // 2026-04-28: since 260428.0.0 (this repo):
-            // AppendV001 wire format extended to carry the legacy `Cmd::UpsertKV`
-            // and `Cmd::Transaction` variants. Without these, AppendV001 could only
-            // carry node/feature/membership/kv-transaction entries.
+            // Streaming AppendV002 RPC carrying the full `Cmd` schema.
             //
-            // 🖥 raft server: decodes both variants from the AppendV001 stream.
-            add(&mut srv, F::AppendV001UpsertKv, ver(260428, 0, 0));
-            add(&mut srv, F::AppendV001Transaction, ver(260428, 0, 0));
-            // 📡 raft client: capability is registered but no client version uses it
-            // yet — the v001 wiring lands in a follow-up commit. Pinned at
-            // `Version::max()` so it does not affect compatibility math today.
-            add(&mut cli, F::AppendV001UpsertKv, Version::max());
-            add(&mut cli, F::AppendV001Transaction, Version::max());
+            // Replaces the never-shipped `AppendV001`. AppendV001 exposed a
+            // streaming endpoint without the legacy `UpsertKV`/`Transaction`
+            // variants; servers in 260217.x.x..260427.x.x silently dropped
+            // unknown oneof tags rather than rejecting them, so a client could
+            // not safely detect schema completeness from the endpoint alone.
+            // AppendV002 is a new RPC name with the complete schema baked in,
+            // making capability detection unambiguous.
+            //
+            // 🖥 raft server: handles AppendV002.
+            add(&mut srv, F::AppendV002, ver(260428, 0, 0));
+            // 📡 raft client: capability is registered but no client version
+            // uses it yet — the v002 streaming wiring lands in a follow-up
+            // commit. Pinned at `Version::max()` so it does not affect
+            // compatibility math today.
+            add(&mut cli, F::AppendV002, Version::max());
         }
 
         FeatureSpec::build(version, srv, cli)

--- a/crates/server/service/src/meta_service/raft_service_impl.rs
+++ b/crates/server/service/src/meta_service/raft_service_impl.rs
@@ -472,14 +472,14 @@ impl<SP: SpawnApi> RaftService for RaftServiceImpl<SP> {
         .await
     }
 
-    type AppendV001Stream = BoxStream<pb::AppendResponse>;
+    type AppendV002Stream = BoxStream<pb::AppendResponse>;
 
-    async fn append_v001(
+    async fn append_v002(
         &self,
         request: Request<Streaming<pb::AppendRequest>>,
-    ) -> Result<Response<Self::AppendV001Stream>, Status> {
+    ) -> Result<Response<Self::AppendV002Stream>, Status> {
         let remote_addr = remote_addr(&request);
-        info!("RaftServiceImpl::append_v001: from:{remote_addr}");
+        info!("RaftServiceImpl::append_v002: from:{remote_addr}");
 
         let input = request.into_inner();
 
@@ -495,7 +495,7 @@ impl<SP: SpawnApi> RaftService for RaftServiceImpl<SP> {
             })
             .take_while(move |r| {
                 if let Err(e) = r {
-                    warn!("append_v001: from:{} input error: {}", addr, e);
+                    warn!("append_v002: from:{} input error: {}", addr, e);
                 }
                 futures::future::ready(r.is_ok())
             })

--- a/crates/server/service/src/network.rs
+++ b/crates/server/service/src/network.rs
@@ -743,7 +743,7 @@ impl<SP: SpawnApi> Network<SP> {
 /// Unary AppendEntries via the legacy single-RPC endpoint.
 ///
 /// Used by [`stream_append_sequential`] in the [`NetStreamAppend`] impl below
-/// as the per-request adapter. A subsequent commit will add an `AppendV001`
+/// as the per-request adapter. A subsequent commit will add an `AppendV002`
 /// fast path on top of this.
 impl<SP: SpawnApi> NetAppend<TypeConfig> for Network<SP> {
     /// Send AppendEntries RPC with automatic payload size management.

--- a/crates/server/service/tests/it/meta_node/meta_node_replication.rs
+++ b/crates/server/service/tests/it/meta_node/meta_node_replication.rs
@@ -369,8 +369,8 @@ async fn test_raft_service_install_snapshot_v004() -> anyhow::Result<()> {
 
 #[test(harness = meta_service_test_harness::<TokioRuntime, _, _>)]
 #[fastrace::trace]
-async fn test_raft_service_append_v001() -> anyhow::Result<()> {
-    // Test the AppendV001 bidirectional streaming gRPC endpoint.
+async fn test_raft_service_append_v002() -> anyhow::Result<()> {
+    // Test the AppendV002 bidirectional streaming gRPC endpoint.
     //
     // Start a single-node leader (node 0, term 1, committed vote) with 3
     // initial log entries. To test `stream_append` we must act as a leader
@@ -410,7 +410,7 @@ async fn test_raft_service_append_v001() -> anyhow::Result<()> {
             leader_commit: Some(prev_log_id_3),
         };
 
-        let resp = client0.append_v001(stream::iter(vec![heartbeat])).await?;
+        let resp = client0.append_v002(stream::iter(vec![heartbeat])).await?;
         let mut output = resp.into_inner();
 
         let first = output.next().await;
@@ -455,7 +455,7 @@ async fn test_raft_service_append_v001() -> anyhow::Result<()> {
             leader_commit: Some(prev_log_id_3),
         };
 
-        let resp = client0.append_v001(stream::iter(vec![append_req])).await?;
+        let resp = client0.append_v002(stream::iter(vec![append_req])).await?;
         let mut output = resp.into_inner();
 
         let first = output.next().await.unwrap()?;
@@ -487,7 +487,7 @@ async fn test_raft_service_append_v001() -> anyhow::Result<()> {
             leader_commit: None,
         };
 
-        let resp = client0.append_v001(stream::iter(vec![stale_req])).await?;
+        let resp = client0.append_v002(stream::iter(vec![stale_req])).await?;
         let mut output = resp.into_inner();
 
         let first = output.next().await.unwrap()?;
@@ -505,8 +505,8 @@ async fn test_raft_service_append_v001() -> anyhow::Result<()> {
 
 #[test(harness = meta_service_test_harness::<TokioRuntime, _, _>)]
 #[fastrace::trace]
-async fn test_raft_service_append_v001_multi_item_stream() -> anyhow::Result<()> {
-    // Test AppendV001 with a single stream containing multiple requests,
+async fn test_raft_service_append_v002_multi_item_stream() -> anyhow::Result<()> {
+    // Test AppendV002 with a single stream containing multiple requests,
     // each carrying multiple log entries. Verifies that:
     // - All requests in one stream produce corresponding responses
     // - Each response's `last_log_id` reflects the last entry of that batch
@@ -564,7 +564,7 @@ async fn test_raft_service_append_v001_multi_item_stream() -> anyhow::Result<()>
         leader_commit: Some(make_log_id(5)),
     };
 
-    let resp = client0.append_v001(stream::iter(vec![req1, req2])).await?;
+    let resp = client0.append_v002(stream::iter(vec![req1, req2])).await?;
     let results: Vec<pb::AppendResponse> = resp.into_inner().try_collect().await?;
 
     assert_eq!(results, vec![
@@ -579,6 +579,180 @@ async fn test_raft_service_append_v001_multi_item_stream() -> anyhow::Result<()>
             last_log_id: Some(make_log_id(8)),
         },
     ]);
+
+    Ok(())
+}
+
+#[test(harness = meta_service_test_harness::<TokioRuntime, _, _>)]
+#[fastrace::trace]
+async fn test_raft_service_append_v002_upsert_kv() -> anyhow::Result<()> {
+    // End-to-end check that AppendV002 round-trips `Cmd::UpsertKV` all the way
+    // through the follower's state-machine apply path. The never-shipped
+    // `AppendV001` silently dropped this oneof tag at the proto layer; the new
+    // endpoint exists precisely to make the trip safe.
+    //
+    // Setup:
+    // - Bootstrap a 2-node cluster: voter node 0 (leader) + learner node 1.
+    // - Stop the leader so it stops replicating; the learner now receives logs
+    //   only via our hand-crafted AppendRequest below.
+    // - Send an AppendRequest carrying one `Cmd::UpsertKV` entry directly to
+    //   the learner's gRPC endpoint, with `leader_commit` advanced to the new
+    //   entry's LogId so the learner commits-and-applies it on the spot.
+    // - Read the learner's state machine and verify the upserted key/value.
+    //
+    // Using a learner (not a voter) for node 1 sidesteps election timing: a
+    // learner cannot start an election when the leader disappears, so the
+    // node's vote stays at the bootstrap value and our AppendRequest's vote
+    // matches without bumping the term.
+
+    let (log_index, tcs) = start_meta_node_cluster(btreeset![0], btreeset![1]).await?;
+    assert_eq!(log_index, 5, "init=3 + add-node-1=2");
+
+    let leader = tcs[0].meta_node();
+    leader.stop().await?;
+
+    let follower = tcs[1].meta_node();
+    let mut client = tcs[1].raft_client().await?;
+
+    // Bootstrap leaves the cluster's last log id at (term=1, node=0, index=5).
+    // We extend the log with one new entry at index 6 written under the same
+    // vote, and commit through that index so the learner applies it.
+    let leader_vote = pb::Vote {
+        term: 1,
+        node_id: 0,
+        committed: true,
+    };
+    let prev_log_id = pb::LogId {
+        term: 1,
+        node_id: 0,
+        index: 5,
+    };
+    let new_log_id = pb::LogId {
+        term: 1,
+        node_id: 0,
+        index: 6,
+    };
+
+    let key = "v002-upsert-apply";
+    let value = b"applied-value".to_vec();
+
+    let entry = pb::LogEntry {
+        log_id: Some(new_log_id),
+        proposed_at_ms: None,
+        cmd: Some(pb::log_entry::Cmd::UpsertKv(pb::CmdUpsertKv {
+            key: key.to_string(),
+            seq: Some(pb::MatchSeq { ge: true, value: 0 }),
+            value: Some(value.clone()),
+            expire_at: None,
+            ttl_ms: None,
+        })),
+    };
+
+    let append_req = pb::AppendRequest {
+        vote: Some(leader_vote),
+        prev_log_id: Some(prev_log_id),
+        entries: vec![entry],
+        leader_commit: Some(new_log_id),
+    };
+
+    let resp = client.append_v002(stream::iter(vec![append_req])).await?;
+    let first = resp.into_inner().next().await.unwrap()?;
+    assert_eq!(first, pb::AppendResponse {
+        rejected_by: None,
+        conflict_log_id: None,
+        last_log_id: Some(new_log_id),
+    });
+
+    // The AppendV002 response only confirms the entry was stored; apply happens
+    // asynchronously. Wait for the learner's state machine to catch up.
+    follower
+        .raft
+        .wait(timeout())
+        .applied_index(Some(6), "learner applied UpsertKV via append_v002")
+        .await?;
+
+    let sm = follower.raft_store.get_sm_v003();
+    let got = sm.get_maybe_expired_kv(key).await?;
+    let seq_v = got.unwrap_or_else(|| panic!("expected key {} after apply", key));
+    assert_eq!(seq_v.data, value);
+
+    Ok(())
+}
+
+#[test(harness = meta_service_test_harness::<TokioRuntime, _, _>)]
+#[fastrace::trace]
+async fn test_raft_service_append_v002_transaction() -> anyhow::Result<()> {
+    // End-to-end check that AppendV002 round-trips `Cmd::Transaction` (the
+    // legacy `TxnRequest` variant) through the follower's apply path. Like
+    // `UpsertKV`, this oneof tag was silently dropped by the never-shipped
+    // `AppendV001`.
+    //
+    // Setup mirrors `test_raft_service_append_v002_upsert_kv`: bootstrap a
+    // voter+learner cluster, stop the leader, then drive the learner's apply
+    // path directly via AppendV002.
+
+    let (log_index, tcs) = start_meta_node_cluster(btreeset![0], btreeset![1]).await?;
+    assert_eq!(log_index, 5, "init=3 + add-node-1=2");
+
+    let leader = tcs[0].meta_node();
+    leader.stop().await?;
+
+    let follower = tcs[1].meta_node();
+    let mut client = tcs[1].raft_client().await?;
+
+    let leader_vote = pb::Vote {
+        term: 1,
+        node_id: 0,
+        committed: true,
+    };
+    let prev_log_id = pb::LogId {
+        term: 1,
+        node_id: 0,
+        index: 5,
+    };
+    let new_log_id = pb::LogId {
+        term: 1,
+        node_id: 0,
+        index: 6,
+    };
+
+    let key = "v002-txn-apply";
+    let value = b"txn-applied-value".to_vec();
+
+    // Empty conditions => trivially-true branch => `if_then` runs.
+    let txn = pb::TxnRequest::new(vec![], vec![pb::TxnOp::put(key, value.clone())]);
+
+    let entry = pb::LogEntry {
+        log_id: Some(new_log_id),
+        proposed_at_ms: None,
+        cmd: Some(pb::log_entry::Cmd::Transaction(txn)),
+    };
+
+    let append_req = pb::AppendRequest {
+        vote: Some(leader_vote),
+        prev_log_id: Some(prev_log_id),
+        entries: vec![entry],
+        leader_commit: Some(new_log_id),
+    };
+
+    let resp = client.append_v002(stream::iter(vec![append_req])).await?;
+    let first = resp.into_inner().next().await.unwrap()?;
+    assert_eq!(first, pb::AppendResponse {
+        rejected_by: None,
+        conflict_log_id: None,
+        last_log_id: Some(new_log_id),
+    });
+
+    follower
+        .raft
+        .wait(timeout())
+        .applied_index(Some(6), "learner applied Transaction via append_v002")
+        .await?;
+
+    let sm = follower.raft_store.get_sm_v003();
+    let got = sm.get_maybe_expired_kv(key).await?;
+    let seq_v = got.unwrap_or_else(|| panic!("expected key {} after apply", key));
+    assert_eq!(seq_v.data, value);
 
     Ok(())
 }


### PR DESCRIPTION

## Changelog

##### change: replace AppendV001 with AppendV002 carrying full Cmd schema
# Summary

Rename the streaming raft append RPC from `AppendV001` to `AppendV002` so the
endpoint name itself encodes the complete `Cmd` schema, including the legacy
`UpsertKV` and `Transaction` variants. The previous `AppendV001` registered at
260217.0.0 was never reached by any client: servers in
260217.x.x..260427.x.x silently dropped unknown oneof tags rather than
rejecting them, so a client could not safely detect schema completeness from
the endpoint alone. A fresh RPC name with the full schema baked in makes
capability detection unambiguous.

# Details

- Renamed the gRPC method `AppendV001` -> `AppendV002` in the proto and the
  matching server impl. gRPC client/server compatibility math is unchanged
  because the v001 endpoint had no shipped clients.
- Replaced the three feature variants `AppendV001`, `AppendV001UpsertKv`, and
  `AppendV001Transaction` with a single `AppendV002`, and dropped the
  260217.0.0 server registration of `AppendV001`. The 260428.0.0 spec now
  registers only `AppendV002` on the server; the client side stays pinned at
  `Version::max()` until the streaming wiring lands in a follow-up.
- Added end-to-end tests that drive an `AppendRequest` carrying
  `Cmd::UpsertKV` and `Cmd::Transaction` directly to a learner's gRPC
  endpoint, then verify the entries are applied through the state machine.
  These are the variants v001 would have silently dropped, so the new
  endpoint is exercised on exactly the paths it exists to make safe. Existing
  streaming tests are renamed to the v002 names.

---


