### PR TITLE
chore: log raft-log flush latency percentiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ pretty_assertions = "1.3.0"
 prometheus-client = "0.22"
 prost = "0.13"
 prost-build = "0.13"
-raft-log = "0.4.1"
+raft-log = "0.4.2"
 rand = { version = "0.8.5", features = ["small_rng", "serde1"] }
 regex = "1.8.1"
 rmp-serde = "1.1.1"

--- a/crates/server/service/src/meta_node/meta_node.rs
+++ b/crates/server/service/src/meta_node/meta_node.rs
@@ -683,7 +683,24 @@ impl<SP: SpawnApi> MetaNode<SP> {
                 "avg_write_us_per_batch": Self::avg_u64(fm.write_us, fm.batch_count),
                 "avg_sync_us_per_sync_batch": Self::avg_u64(fm.sync_us, fm.sync_batch_count),
                 "avg_batch_us": Self::avg_u64(fm.batch_us, fm.batch_count),
+                "latency_percentiles_us": {
+                    "group_wait": Self::latency_percentiles_to_json(&fm.group_wait_percentiles),
+                    "queued_wait": Self::latency_percentiles_to_json(&fm.queued_wait_percentiles),
+                    "write": Self::latency_percentiles_to_json(&fm.write_percentiles),
+                    "sync": Self::latency_percentiles_to_json(&fm.sync_percentiles),
+                    "batch": Self::latency_percentiles_to_json(&fm.batch_percentiles),
+                },
             },
+        })
+    }
+
+    fn latency_percentiles_to_json(
+        percentiles: &raft_log::FlushLatencyPercentiles,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "p50": percentiles.p50_us,
+            "p90": percentiles.p90_us,
+            "p99": percentiles.p99_us,
         })
     }
 


### PR DESCRIPTION

## Changelog

##### chore: log raft-log flush latency percentiles
Patch raft-log to the local 0.4.2 workspace while evaluating the new WAL flush metrics.

Emit p50, p90, and p99 latency stats for group wait, queued wait, write, sync, and batch time in the raft log stats report.

Keep raft gRPC TCP_NODELAY enabled so the raft connection path remains configured for low-latency writes.

---


