### PR TITLE
refactor: databend-meta make checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "260512.0.0"
+version = "260512.1.0"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ databend-meta-version = { path = "crates/common/version" }
 base2histogram = "0.2.3"
 databend-base = "0.4.0"
 map-api = "0.4.2"
-openraft = { version = "=0.10.0-alpha.19", features = ["serde", "tracing-log", "runtime-stats"] }
+openraft = { version = "=0.10.0-alpha.20", features = ["serde", "tracing-log", "runtime-stats"] }
 sled = { version = "0.34", default-features = false }
 state-machine-api = "0.3.4"
 

--- a/crates/client/kvapi/Cargo.toml
+++ b/crates/client/kvapi/Cargo.toml
@@ -9,7 +9,6 @@ edition = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = { workspace = true }
 async-trait = { workspace = true }
 databend-meta-client-types = { workspace = true }
 display-more = { workspace = true }

--- a/crates/common/version/src/grpc_changelog.rs
+++ b/crates/common/version/src/grpc_changelog.rs
@@ -156,6 +156,12 @@ pub fn grpc_changelog() -> BTreeMap<Version, GrpcVersionCompat> {
         min_server: ver(260217, 0, 0),
     });
 
+    // 260512.1.0: no grpc compatibility change.
+    m.insert(ver(260512, 1, 0), GrpcVersionCompat {
+        min_client: ver(1, 2, 676),
+        min_server: ver(260217, 0, 0),
+    });
+
     m
 }
 

--- a/crates/common/version/src/lib.rs
+++ b/crates/common/version/src/lib.rs
@@ -140,17 +140,17 @@ mod tests {
 
     #[test]
     fn test_version_string() {
-        assert_eq!(version_str(), "260512.0.0");
+        assert_eq!(version_str(), "260512.1.0");
     }
 
     #[test]
     fn test_semver_components() {
-        assert_eq!(semver_tuple(version()), (260512, 0, 0));
+        assert_eq!(semver_tuple(version()), (260512, 1, 0));
     }
 
     #[test]
     fn test_semver_display() {
-        assert_eq!(version().to_semver().to_string(), "260512.0.0");
+        assert_eq!(version().to_semver().to_string(), "260512.1.0");
     }
 
     #[test]

--- a/crates/tests/raft-protocol-compat/bin-current/Cargo.lock
+++ b/crates/tests/raft-protocol-compat/bin-current/Cargo.lock
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta"
-version = "260512.0.0"
+version = "260512.1.0"
 dependencies = [
  "anyerror",
  "anyhow",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-base"
-version = "260512.0.0"
+version = "260512.1.0"
 dependencies = [
  "anyerror",
  "deepsize",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client"
-version = "260512.0.0"
+version = "260512.1.0"
 dependencies = [
  "anyerror",
  "arrow-flight",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client-types"
-version = "260512.0.0"
+version = "260512.1.0"
 dependencies = [
  "anyerror",
  "databend-meta-proto",
@@ -1025,9 +1025,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi"
-version = "260512.0.0"
+version = "260512.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "databend-meta-client-types",
  "display-more 0.2.6",
@@ -1039,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi-test-suite"
-version = "260512.0.0"
+version = "260512.1.0"
 dependencies = [
  "anyhow",
  "databend-meta-client-types",
@@ -1054,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-proto"
-version = "260512.0.0"
+version = "260512.1.0"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -1076,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-raft-store"
-version = "260512.0.0"
+version = "260512.1.0"
 dependencies = [
  "anyerror",
  "anyhow",
@@ -1116,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-runtime-api"
-version = "260512.0.0"
+version = "260512.1.0"
 dependencies = [
  "env_logger",
  "hickory-resolver",
@@ -1128,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-sled-store"
-version = "260512.0.0"
+version = "260512.1.0"
 dependencies = [
  "anyerror",
  "byteorder",
@@ -1145,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-types"
-version = "260512.0.0"
+version = "260512.1.0"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -1172,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-version"
-version = "260512.0.0"
+version = "260512.1.0"
 dependencies = [
  "semver",
 ]
@@ -2557,9 +2556,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openraft"
-version = "0.10.0-alpha.19"
+version = "0.10.0-alpha.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be61988143b295becb312ba3aa87180fab9cede5034e71cdfc56b67307e527ce"
+checksum = "42a7b7775774f72c1ec9c4a7a74ec5274515c66c0af40b0f8119ebd36ec3fde4"
 dependencies = [
  "anyerror",
  "backoff-series",
@@ -2587,9 +2586,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-macros"
-version = "0.10.0-alpha.19"
+version = "0.10.0-alpha.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8755bfaeea7601f72329d386a32947cfed281272c8f8434dfdfd6d5d465eaa5"
+checksum = "880853cd85c2dd7883122134abcc5483005dd175d6027e9e00c1eede8fd2a956"
 dependencies = [
  "chrono",
  "proc-macro2",
@@ -2600,9 +2599,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt"
-version = "0.10.0-alpha.19"
+version = "0.10.0-alpha.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82652038a6558d47b98e960fc76b9798f2fdecec01dc3d170883ee000cef4f22"
+checksum = "0ba87cea8e45601807f2537fd9e657e02c9ee2fdaa9be4ece013b296b03b2c97"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -2613,9 +2612,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt-tokio"
-version = "0.10.0-alpha.19"
+version = "0.10.0-alpha.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3967c661dc807d63c187069e4c4532b7115f571605197bde1340c9d0d7d29ca7"
+checksum = "2a539ef5ef89d4da720c56300aeb702d6ddf2a9fa653b029b79d30e5f8cf68fa"
 dependencies = [
  "futures-util",
  "openraft-rt",
@@ -3012,10 +3011,11 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "raft-log"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afe9ff8116842d0a2c365366a3e9f6f219636c1dc14a8411a5876eb5a0654f2b"
+checksum = "8b38acccc1f19eac73c16dbfaf5eecf0ea4f6af71844ef06acd297d5311ab0cc"
 dependencies = [
+ "base2histogram",
  "byteorder",
  "codeq",
  "display-more 0.2.6",

--- a/crates/tests/raft-protocol-compat/bin-current/Cargo.toml
+++ b/crates/tests/raft-protocol-compat/bin-current/Cargo.toml
@@ -19,7 +19,7 @@ databend-meta-runtime-api = { path = "../../../common/runtime-api" }
 databend-meta-types = { path = "../../../server/types" }
 env_logger = "0.11"
 log = "0.4"
-openraft = "=0.10.0-alpha.19"
+openraft = "=0.10.0-alpha.20"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1.35", features = ["full"] }


### PR DESCRIPTION

## Changelog

##### refactor: databend-meta make checks

##### Bump version to 260512.1.0
Update the workspace version and version crate expectations to the next 260512 minor release. Add a gRPC compatibility changelog entry for 260512.1.0 because this release does not change gRPC compatibility.


##### Upgrade openraft to 0.10.0-alpha.20
Use the latest alpha.20 Openraft release for Databend Meta while keeping the existing feature set unchanged.

---

- Improvement
