### PR TITLE
chore: deps: bump crate-ci/typos from 1.33.1 to 1.46.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,4 +68,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: crate-ci/typos@v1.33.1
+      - uses: crate-ci/typos@v1.46.0


### PR DESCRIPTION

## Changelog

##### chore: deps: bump crate-ci/typos from 1.33.1 to 1.46.0
Bumps [crate-ci/typos](https://github.com/crate-ci/typos) from 1.33.1 to 1.46.0.
- [Release notes](https://github.com/crate-ci/typos/releases)
- [Changelog](https://github.com/crate-ci/typos/blob/master/CHANGELOG.md)
- [Commits](https://github.com/crate-ci/typos/compare/v1.33.1...v1.46.0)

---
updated-dependencies:
- dependency-name: crate-ci/typos
  dependency-version: 1.46.0
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

---


