### PR TITLE
change: remove kvapi relationship hooks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "yearly"
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "yearly"

--- a/crates/client/kvapi/src/key.rs
+++ b/crates/client/kvapi/src/key.rs
@@ -23,25 +23,18 @@ use crate::StructKey;
 /// A `kvapi::KVApi` key: a `StructKey` paired with the value type stored at it.
 ///
 /// `StructKey` provides the encoding (`PREFIX`, `to_string_key`, `from_str_key`);
-/// this trait layers on the kvapi-specific `ValueType` association and the
-/// `parent()` relation between hierarchical keys.
+/// this trait layers on the kvapi-specific `ValueType` association.
 pub trait Key: StructKey + Debug
 where Self: Sized
 {
     type ValueType: kvapi::Value;
-
-    /// Return the parent key of this key.
-    ///
-    /// For example, a table name's(`(database_id, table_name)`) parent is the database id.
-    fn parent(&self) -> Option<String>;
 }
 
+/// `DirName<K>` participates in `Key` whenever the inner `K` does.
+///
+/// It carries the inner key's `ValueType`.
 impl<K: Key> Key for DirName<K> {
     type ValueType = K::ValueType;
-
-    fn parent(&self) -> Option<String> {
-        unimplemented!("DirName is not a record thus it has no parent")
-    }
 }
 
 #[cfg(test)]

--- a/crates/client/kvapi/src/testing.rs
+++ b/crates/client/kvapi/src/testing.rs
@@ -35,18 +35,10 @@ pub(crate) struct FooValue;
 
 impl Key for FooKey {
     type ValueType = FooValue;
-
-    fn parent(&self) -> Option<String> {
-        None
-    }
 }
 
 impl Value for FooValue {
     type KeyType = FooKey;
-
-    fn dependency_keys(&self, _key: &Self::KeyType) -> impl IntoIterator<Item = String> {
-        []
-    }
 }
 
 #[cfg(test)]

--- a/crates/client/kvapi/src/value.rs
+++ b/crates/client/kvapi/src/value.rs
@@ -19,13 +19,4 @@ use crate as kvapi;
 /// A value that can be stored in kvapi::KVApi.
 pub trait Value: Debug {
     type KeyType: kvapi::Key;
-
-    /// Return keys this value depends on.
-    ///
-    /// For example, the name-to-id record `database-name -> a database-id`
-    /// depends on the `database-id -> database-meta` record.
-    /// Thus `DatabaseId::dependency_keys()` returns itself for further traversing.
-    ///
-    /// It accepts the key bound to this value as an argument.
-    fn dependency_keys(&self, _key: &Self::KeyType) -> impl IntoIterator<Item = String>;
 }


### PR DESCRIPTION

## Changelog

##### change: remove kvapi relationship hooks
# Summary

Remove the parent/dependency hook methods from kvapi key and value traits now that relationship traversal is handled outside per-key implementations.

# Details

The kvapi public trait surface now keeps only the key-to-value and value-to-key type associations, avoiding boilerplate implementations for metadata keys that no longer provide unique behavior.

The test helper key/value implementation was reduced to the same minimal contract so downstream crates can remove their redundant method bodies consistently.


##### chore: dependabot check: yearly

---


