### PR TITLE
Bump version to 260512.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "260512.1.0"
+version = "260512.2.0"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false

--- a/crates/common/version/src/grpc_changelog.rs
+++ b/crates/common/version/src/grpc_changelog.rs
@@ -162,6 +162,12 @@ pub fn grpc_changelog() -> BTreeMap<Version, GrpcVersionCompat> {
         min_server: ver(260217, 0, 0),
     });
 
+    // 260512.2.0: no grpc compatibility change.
+    m.insert(ver(260512, 2, 0), GrpcVersionCompat {
+        min_client: ver(1, 2, 676),
+        min_server: ver(260217, 0, 0),
+    });
+
     m
 }
 

--- a/crates/common/version/src/lib.rs
+++ b/crates/common/version/src/lib.rs
@@ -140,17 +140,17 @@ mod tests {
 
     #[test]
     fn test_version_string() {
-        assert_eq!(version_str(), "260512.1.0");
+        assert_eq!(version_str(), "260512.2.0");
     }
 
     #[test]
     fn test_semver_components() {
-        assert_eq!(semver_tuple(version()), (260512, 1, 0));
+        assert_eq!(semver_tuple(version()), (260512, 2, 0));
     }
 
     #[test]
     fn test_semver_display() {
-        assert_eq!(version().to_semver().to_string(), "260512.1.0");
+        assert_eq!(version().to_semver().to_string(), "260512.2.0");
     }
 
     #[test]

--- a/crates/tests/raft-protocol-compat/bin-current/Cargo.lock
+++ b/crates/tests/raft-protocol-compat/bin-current/Cargo.lock
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta"
-version = "260512.1.0"
+version = "260512.2.0"
 dependencies = [
  "anyerror",
  "anyhow",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-base"
-version = "260512.1.0"
+version = "260512.2.0"
 dependencies = [
  "anyerror",
  "deepsize",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client"
-version = "260512.1.0"
+version = "260512.2.0"
 dependencies = [
  "anyerror",
  "arrow-flight",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client-types"
-version = "260512.1.0"
+version = "260512.2.0"
 dependencies = [
  "anyerror",
  "databend-meta-proto",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi"
-version = "260512.1.0"
+version = "260512.2.0"
 dependencies = [
  "async-trait",
  "databend-meta-client-types",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi-test-suite"
-version = "260512.1.0"
+version = "260512.2.0"
 dependencies = [
  "anyhow",
  "databend-meta-client-types",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-proto"
-version = "260512.1.0"
+version = "260512.2.0"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-raft-store"
-version = "260512.1.0"
+version = "260512.2.0"
 dependencies = [
  "anyerror",
  "anyhow",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-runtime-api"
-version = "260512.1.0"
+version = "260512.2.0"
 dependencies = [
  "env_logger",
  "hickory-resolver",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-sled-store"
-version = "260512.1.0"
+version = "260512.2.0"
 dependencies = [
  "anyerror",
  "byteorder",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-types"
-version = "260512.1.0"
+version = "260512.2.0"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-version"
-version = "260512.1.0"
+version = "260512.2.0"
 dependencies = [
  "semver",
 ]


### PR DESCRIPTION

## Changelog

##### Bump version to 260512.2.0
# Summary

Update the workspace to the next 260512 minor release and keep version assertions and compatibility metadata aligned.

# Details

Add a gRPC compatibility changelog entry for 260512.2.0 because this release does not change gRPC client or server compatibility.

---


