### PR TITLE
change: update raft-log to 0.4.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ pretty_assertions = "1.3.0"
 prometheus-client = "0.22"
 prost = "0.13"
 prost-build = "0.13"
-raft-log = "0.4.2"
+raft-log = "0.4.4"
 rand = { version = "0.8.5", features = ["small_rng", "serde1"] }
 regex = "1.8.1"
 rmp-serde = "1.1.1"

--- a/crates/server/raft-store/src/config.rs
+++ b/crates/server/raft-store/src/config.rs
@@ -22,6 +22,7 @@ use std::time::Duration;
 use databend_meta_runtime_api::SpawnApi;
 use databend_meta_types::Endpoint;
 use databend_meta_types::raft_types::NodeId;
+use raft_log::chunked_wal::Config as WalConfig;
 
 use crate::MetaStartupError;
 use crate::ondisk::DATA_VERSION;
@@ -263,15 +264,17 @@ impl RaftConfig {
         let dir = p.to_str().unwrap().to_string();
 
         raft_log_v004::RaftLogConfig {
-            dir,
+            wal: WalConfig {
+                dir,
+                read_buffer_size: None,
+                chunk_max_records: Some(self.log_wal_chunk_max_records as usize),
+                chunk_max_size: Some(self.log_wal_chunk_max_size as usize),
+                truncate_incomplete_record: None,
+                flush_batch_wait: Some(Duration::from_millis(1)),
+                flush_batch_max_items: Some(1024),
+            },
             log_cache_max_items: Some(self.log_cache_max_items as usize),
             log_cache_capacity: Some(self.log_cache_capacity as usize),
-            chunk_max_records: Some(self.log_wal_chunk_max_records as usize),
-            chunk_max_size: Some(self.log_wal_chunk_max_size as usize),
-            read_buffer_size: None,
-            truncate_incomplete_record: None,
-            flush_batch_wait: Some(Duration::from_millis(1)),
-            flush_batch_max_items: Some(1024),
         }
     }
 

--- a/crates/server/raft-store/tests/it/raft_log_v004_recovery.rs
+++ b/crates/server/raft-store/tests/it/raft_log_v004_recovery.rs
@@ -24,6 +24,7 @@ use std::fs::OpenOptions;
 use std::path::Path;
 use std::sync::Arc;
 
+use databend_meta_raft_store::raft_log::chunked_wal::Config as WalConfig;
 use databend_meta_raft_store::raft_log_v004::Cw;
 use databend_meta_raft_store::raft_log_v004::RaftLogConfig;
 use databend_meta_raft_store::raft_log_v004::RaftLogV004;
@@ -71,15 +72,17 @@ async fn test_truncation_recovery(bytes_to_truncate: u64) -> anyhow::Result<()> 
     fs::create_dir_all(&log_dir)?;
 
     let config = Arc::new(RaftLogConfig {
-        dir: log_dir.to_str().unwrap().to_string(),
+        wal: WalConfig {
+            dir: log_dir.to_str().unwrap().to_string(),
+            read_buffer_size: None,
+            chunk_max_records: Some(100),
+            chunk_max_size: Some(1024 * 1024),
+            truncate_incomplete_record: Some(true),
+            flush_batch_wait: None,
+            flush_batch_max_items: None,
+        },
         log_cache_max_items: Some(1000),
         log_cache_capacity: Some(1024 * 1024),
-        chunk_max_records: Some(100),
-        chunk_max_size: Some(1024 * 1024),
-        read_buffer_size: None,
-        truncate_incomplete_record: Some(true),
-        flush_batch_wait: None,
-        flush_batch_max_items: None,
     });
 
     let num_entries: u64 = 10;

--- a/crates/server/service/src/meta_node/meta_node.rs
+++ b/crates/server/service/src/meta_node/meta_node.rs
@@ -1848,12 +1848,11 @@ pub(crate) fn event_filter_from_filter_type(filter_type: FilterType) -> EventFil
 
 #[cfg(test)]
 mod tests {
-    use databend_meta_raft_store::raft_log_v004::RaftLogTypes;
     use databend_meta_runtime_api::TokioRuntime;
 
     use super::*;
 
-    fn empty_chunk_stat() -> raft_log::ChunkStat<RaftLogTypes> {
+    fn empty_chunk_stat<T: Default>() -> raft_log::ChunkStat<T> {
         raft_log::ChunkStat {
             chunk_id: raft_log::ChunkId(0),
             records_count: 0,

--- a/crates/server/service/src/store/store.rs
+++ b/crates/server/service/src/store/store.rs
@@ -89,7 +89,7 @@ impl<SP: SpawnApi> RaftStore<SP> {
 
         let raft_log_config = Arc::new(config.to_raft_log_config());
 
-        let dir = &raft_log_config.dir;
+        let dir = &raft_log_config.wal.dir;
 
         fs::create_dir_all(dir).map_err(|e| {
             let err = io::Error::new(
@@ -100,7 +100,7 @@ impl<SP: SpawnApi> RaftStore<SP> {
         })?;
 
         let mut log = RaftLogV004::open(raft_log_config.clone()).map_err(to_startup_err)?;
-        info!("RaftLog opened at: {}", raft_log_config.dir);
+        info!("RaftLog opened at: {}", raft_log_config.wal.dir);
 
         let state = log.log_state();
         info!("log_state: {:?}", state);

--- a/crates/tests/raft-protocol-compat/bin-current/Cargo.lock
+++ b/crates/tests/raft-protocol-compat/bin-current/Cargo.lock
@@ -670,6 +670,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "chunked-wal"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cb4664e0ebe1a145b88ebc9973327512d3997f796ce49d41b08196cf0d51285"
+dependencies = [
+ "base2histogram",
+ "byteorder",
+ "codeq 0.6.0",
+ "fs2",
+ "log",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,6 +728,19 @@ name = "codeq"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a72a59f33777d39160f5b4a8a258732cb6b538607c28b65eaa3b96f7cd35b994"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "crc32fast",
+ "derive_more 1.0.0",
+ "serde",
+]
+
+[[package]]
+name = "codeq"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ed6506d61f6bd1ee4f67f589c632cd3ee6fbbf468a00c166785d466f8bae81e"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -891,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta"
-version = "260512.2.0"
+version = "260512.3.0"
 dependencies = [
  "anyerror",
  "anyhow",
@@ -940,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-base"
-version = "260512.2.0"
+version = "260512.3.0"
 dependencies = [
  "anyerror",
  "deepsize",
@@ -955,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client"
-version = "260512.2.0"
+version = "260512.3.0"
 dependencies = [
  "anyerror",
  "arrow-flight",
@@ -988,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client-types"
-version = "260512.2.0"
+version = "260512.3.0"
 dependencies = [
  "anyerror",
  "databend-meta-proto",
@@ -1025,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi"
-version = "260512.2.0"
+version = "260512.3.0"
 dependencies = [
  "async-trait",
  "databend-meta-client-types",
@@ -1038,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi-test-suite"
-version = "260512.2.0"
+version = "260512.3.0"
 dependencies = [
  "anyhow",
  "databend-meta-client-types",
@@ -1053,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-proto"
-version = "260512.2.0"
+version = "260512.3.0"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -1075,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-raft-store"
-version = "260512.2.0"
+version = "260512.3.0"
 dependencies = [
  "anyerror",
  "anyhow",
@@ -1115,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-runtime-api"
-version = "260512.2.0"
+version = "260512.3.0"
 dependencies = [
  "env_logger",
  "hickory-resolver",
@@ -1127,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-sled-store"
-version = "260512.2.0"
+version = "260512.3.0"
 dependencies = [
  "anyerror",
  "byteorder",
@@ -1144,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-types"
-version = "260512.2.0"
+version = "260512.3.0"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -1171,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-version"
-version = "260512.2.0"
+version = "260512.3.0"
 dependencies = [
  "semver",
 ]
@@ -3011,15 +3038,15 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "raft-log"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b38acccc1f19eac73c16dbfaf5eecf0ea4f6af71844ef06acd297d5311ab0cc"
+checksum = "4290f29c4516c8bbd0bf3ce01d59db968dfc071d056e458ff38e74457473c506"
 dependencies = [
  "base2histogram",
  "byteorder",
- "codeq",
+ "chunked-wal",
+ "codeq 0.6.0",
  "display-more 0.2.6",
- "fs2",
  "log",
  "thiserror 1.0.69",
 ]
@@ -3263,7 +3290,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "clap",
- "codeq",
+ "codeq 0.5.2",
  "futures",
  "futures-async-stream",
  "log",


### PR DESCRIPTION

## Changelog

##### change: update raft-log to 0.4.4
# Summary

Move meta storage to the latest raft-log release and adapt configuration construction to the updated public API.

# Details

- Update the workspace dependency to `raft-log` 0.4.4 so meta uses the published release with explicit WAL config access.
- Build raft-log configuration with named struct fields, including the nested WAL config, so future config shape changes are visible at compile time.
- Read the raft log directory through the nested WAL config path used by the new API.

---


