### PR TITLE
feat: add grpc-compat binary for gRPC version compatibility

### DIFF
--- a/crates/common/version/src/bin/grpc-compat.rs
+++ b/crates/common/version/src/bin/grpc-compat.rs
@@ -1,0 +1,58 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Prints gRPC client/server protocol compatibility per CalVer release.
+//!
+//! For each CalVer major release, prints the minimum compatible client and
+//! server versions, matching the format of databend's
+//! `external-meta-min-compatibles.txt`:
+//!
+//! ```text
+//! version         MIN_CLIENT             MIN_SERVER
+//! ```
+//!
+//! `MIN_CLIENT` is the oldest client that can connect to a server of that
+//! version; `MIN_SERVER` is the oldest server that client can connect to.
+//!
+//! Run with: `cargo run -p databend-meta-version --bin grpc-compat`
+
+use databend_meta_version::GrpcSpec;
+use databend_meta_version::Version;
+
+fn main() {
+    let spec = GrpcSpec::load();
+
+    println!("version         MIN_CLIENT             MIN_SERVER");
+    println!("{}", "-".repeat(73));
+
+    for version in candidate_versions() {
+        let min_client = spec.compatible_client_range(version).0.to_string();
+        let min_server = spec.compatible_server_range(version).0.to_string();
+        // `Version`'s `Display` ignores format width; stringify before padding.
+        let version = version.to_string();
+        println!("{version:<16}{min_client:<23}{min_server}");
+    }
+}
+
+/// CalVer major releases to report, oldest first.
+///
+/// Extend this when a new CalVer major is tagged.
+fn candidate_versions() -> Vec<Version> {
+    vec![
+        Version::new(260205, 0, 0),
+        Version::new(260312, 0, 0),
+        Version::new(260428, 0, 0),
+        Version::new(260512, 0, 0),
+    ]
+}

--- a/crates/common/version/src/feature_span.rs
+++ b/crates/common/version/src/feature_span.rs
@@ -136,6 +136,9 @@ pub(crate) fn add_optional<F: FeatureSet>(
 }
 
 /// Record that a feature was removed at `version`.
+///
+/// `version` must be greater than `since`: an optional feature
+/// (`since = Version::max()`) was never added and therefore cannot be removed.
 pub(crate) fn remove<F: FeatureSet>(
     features: &mut BTreeMap<F, FeatureSpan<F>>,
     feature: F,
@@ -147,6 +150,12 @@ pub(crate) fn remove<F: FeatureSet>(
 
     debug_assert!(span.since != Version::min());
     debug_assert!(span.until == Version::max());
+    debug_assert!(
+        version > span.since,
+        "remove version ({}) must be > since ({}): an optional feature (since = max) was never added",
+        version,
+        span.since
+    );
 
     span.until = version;
 }

--- a/crates/common/version/src/feature_span.rs
+++ b/crates/common/version/src/feature_span.rs
@@ -226,40 +226,72 @@ impl<F: FeatureSet> FeatureSpec<F> {
 
     /// Minimum server version that can serve this client.
     ///
-    /// Returns `max(server.since)` across all features the client requires
-    /// at `self.version`.
+    /// The lower bound of `compatible_server_range` at `self.version`.
     pub fn min_compatible_server_version(&self) -> Version {
-        let mut min_server = Version::min();
+        self.compatible_server_range(self.version).0
+    }
+
+    /// Server versions that can serve a client running `client_version`.
+    ///
+    /// The server must provide every feature the client uses, so the range is
+    /// the intersection of the providing spans `[server.since, server.until)`
+    /// over the features active on the client at `client_version`.
+    pub fn compatible_server_range(&self, client_version: Version) -> (Version, Version) {
+        let mut lo = Version::min();
+        let mut hi = Version::max();
 
         for feature in F::all() {
-            let client_lt = self.client_features.get(feature).unwrap();
-            let server_lt = self.server_features.get(feature).unwrap();
+            let client_span = self.client_features.get(feature).unwrap();
+            let server_span = self.server_features.get(feature).unwrap();
 
-            if client_lt.is_active_at(self.version) {
-                min_server = min_server.max(server_lt.since);
+            if client_span.is_active_at(client_version) {
+                lo = lo.max(server_span.since);
+                hi = hi.min(server_span.until);
             }
         }
 
-        min_server
+        (lo, hi)
     }
 
     /// Minimum client version that can connect to this server.
     ///
-    /// Returns `max(client.until)` across all features the server has
-    /// removed at `self.version`.
+    /// The lower bound of `compatible_client_range` at `self.version`.
     pub fn min_compatible_client_version(&self) -> Version {
-        let mut min_client = Version::min();
+        self.compatible_client_range(self.version).0
+    }
+
+    /// Client versions that a server running `server_version` can serve.
+    ///
+    /// The client must not require a feature the server lacks. Each feature the
+    /// server does not provide excludes the client from that feature's usage
+    /// span `[client.since, client.until)`:
+    /// - not yet added (`server_version < server.since`): the client must
+    ///   predate `client.since` (caps the range above).
+    /// - removed (`server_version >= server.until`): the client must have
+    ///   reached `client.until` (floors the range below).
+    pub fn compatible_client_range(&self, server_version: Version) -> (Version, Version) {
+        let mut lo = Version::min();
+        let mut hi = Version::max();
 
         for feature in F::all() {
-            let client_lt = self.client_features.get(feature).unwrap();
-            let server_lt = self.server_features.get(feature).unwrap();
+            let client_span = self.client_features.get(feature).unwrap();
+            let server_span = self.server_features.get(feature).unwrap();
 
-            if !server_lt.is_active_at(self.version) {
-                min_client = min_client.max(client_lt.until);
+            // Skip features the client never requires. `add_optional` records an
+            // optional-only capability with `since = Version::max()`: the client
+            // can fall back, so the server dropping it must not exclude any peer.
+            if client_span.since == Version::max() {
+                continue;
+            }
+
+            if server_version < server_span.since {
+                hi = hi.min(client_span.since);
+            } else if server_version >= server_span.until {
+                lo = lo.max(client_span.until);
             }
         }
 
-        min_client
+        (lo, hi)
     }
 }
 

--- a/crates/common/version/src/raft_spec.rs
+++ b/crates/common/version/src/raft_spec.rs
@@ -109,62 +109,6 @@ impl RaftSpec {
         FeatureSpec::build(version, srv, cli)
     }
 
-    /// Server versions that can serve a raft-client running `client_version`.
-    ///
-    /// The peer (as server) must provide every feature this client uses, so the
-    /// range is the intersection of the providing spans `[server.since,
-    /// server.until)` over the features active on the client at `client_version`.
-    fn compatible_server_range(&self, client_version: Version) -> (Version, Version) {
-        let mut lo = Version::min();
-        let mut hi = Version::max();
-
-        for feature in RaftFeature::all() {
-            let client_span = self.client_features().get(feature).unwrap();
-            let server_span = self.server_features().get(feature).unwrap();
-
-            if client_span.is_active_at(client_version) {
-                lo = lo.max(server_span.since);
-                hi = hi.min(server_span.until);
-            }
-        }
-
-        (lo, hi)
-    }
-
-    /// Client versions that a raft-server running `server_version` can serve.
-    ///
-    /// The peer (as client) must not use any feature this server lacks. Each
-    /// feature the server does not provide excludes the peer-client from that
-    /// feature's usage span `[client.since, client.until)`:
-    /// - not yet added (`server_version < server.since`): the peer-client must
-    ///   predate `client.since` (caps the range above).
-    /// - removed (`server_version >= server.until`): the peer-client must have
-    ///   reached `client.until` (floors the range below).
-    fn compatible_client_range(&self, server_version: Version) -> (Version, Version) {
-        let mut lo = Version::min();
-        let mut hi = Version::max();
-
-        for feature in RaftFeature::all() {
-            let client_span = self.client_features().get(feature).unwrap();
-            let server_span = self.server_features().get(feature).unwrap();
-
-            // Skip features the client never requires. `add_optional` records an
-            // optional-only capability with `since = Version::max()`: the client
-            // can fall back, so the server dropping it must not exclude any peer.
-            if client_span.since == Version::max() {
-                continue;
-            }
-
-            if server_version < server_span.since {
-                hi = hi.min(client_span.since);
-            } else if server_version >= server_span.until {
-                lo = lo.max(client_span.until);
-            }
-        }
-
-        (lo, hi)
-    }
-
     /// The half-open range `[min, max)` of peer node versions that a node
     /// running `node_version` can form a working raft connection with.
     ///

--- a/crates/common/version/src/raft_spec.rs
+++ b/crates/common/version/src/raft_spec.rs
@@ -148,6 +148,13 @@ impl RaftSpec {
             let client_span = self.client_features().get(feature).unwrap();
             let server_span = self.server_features().get(feature).unwrap();
 
+            // Skip features the client never requires. `add_optional` records an
+            // optional-only capability with `since = Version::max()`: the client
+            // can fall back, so the server dropping it must not exclude any peer.
+            if client_span.since == Version::max() {
+                continue;
+            }
+
             if server_version < server_span.since {
                 hi = hi.min(client_span.since);
             } else if server_version >= server_span.until {
@@ -280,6 +287,40 @@ mod tests {
         assert_eq!(
             spec.compatible_peer_range(v(2, 5, 0)),
             (v(1, 5, 0), Version::max())
+        );
+    }
+
+    #[test]
+    fn test_compatible_peer_range_with_removed_optional_feature() {
+        use std::collections::BTreeMap;
+
+        use crate::feature_span::remove;
+
+        let v = |a, b, c| Version::new(a, b, c);
+
+        // A feature that was only ever optional for clients (add_optional, never
+        // promoted to required) and is later removed on the server must not
+        // exclude any peer: optional clients fall back. All other features stay
+        // active from 1.0.0 onward.
+        let optional = RaftFeature::AppendV002;
+        let mut srv = BTreeMap::new();
+        let mut cli = BTreeMap::new();
+        for &feature in RaftFeature::all() {
+            add(&mut srv, feature, v(1, 0, 0));
+            if feature == optional {
+                add_optional(&mut cli, feature, v(1, 0, 0));
+            } else {
+                add(&mut cli, feature, v(1, 0, 0));
+            }
+        }
+        remove(&mut srv, optional, v(2, 0, 0));
+        let spec = FeatureSpec::build(v(1, 0, 0), srv, cli);
+
+        // A server past the optional feature's removal still serves peers: the
+        // range stays [1.0.0, ∞) instead of collapsing to an empty range.
+        assert_eq!(
+            spec.compatible_peer_range(v(2, 5, 0)),
+            (v(1, 0, 0), Version::max())
         );
     }
 }


### PR DESCRIPTION

## Changelog

##### feat: add grpc-compat binary for gRPC version compatibility
# Summary

Adds a `grpc-compat` binary that prints, per CalVer major release, the
minimum compatible gRPC client and server versions — the same data and
format as databend's `external-meta-min-compatibles.txt`. The supporting
refactor lets the raft and gRPC binaries share one compatibility-range
computation.

# Details

- Move `compatible_server_range` / `compatible_client_range` from
  `impl RaftSpec` into the generic `FeatureSpec<F>` and make them public.
  The computation depends only on feature spans, not the feature enum, so
  the gRPC spec reuses it. `compatible_peer_range` stays raft-specific (a
  raft node is simultaneously client and server) and composes the two.

- Collapse `min_compatible_server_version` / `min_compatible_client_version`
  into delegates over the range lower bounds, dropping the duplicated loops.
  Behavior at the build version is unchanged, as the existing
  min-version tests confirm.

- The binary derives `MIN_CLIENT` / `MIN_SERVER` from the range lower
  bounds. The full range — not a min-only helper — is required for
  correctness at past releases: a server feature not yet added must cap
  the client's upper bound rather than raise its minimum.

Example:

    cargo run -p databend-meta-version --bin grpc-compat

    version         MIN_CLIENT             MIN_SERVER
    -------------------------------------------------------------------------
    260205.0.0      1.2.676                1.2.770
    260312.0.0      1.2.676                260217.0.0
    260428.0.0      1.2.676                260217.0.0
    260512.0.0      1.2.676                260217.0.0


##### fix: ignore optional features in raft peer compatibility range
# Summary

A server dropping a feature that clients only ever used optionally
collapsed the computed raft peer-compatibility range to empty, even
though optional clients fall back when a peer lacks the feature. The
range computation now skips optional features, and the feature model
rejects removing a feature that was never required.

# Details

- compatible_client_range skips client features whose `since` is
  `Version::max()` (optional). Previously, a server past such a feature's
  removal floored the lower bound to an impossible version and emptied the
  range. This matches how min_compatible_server_version already excludes
  optional features.

- remove() now asserts `version > since`. An optional feature has
  `since == max` and was never truly added, so removing it is a
  programming error rather than a valid span; the assert fails loudly at
  the call site instead of silently producing a backwards `[since, until)`.

- Regression test for the optional-feature-removed-on-server case.

- Ref: PR #150 review comment r3335024349

---

- Bug Fix
