### PR TITLE
chore: bump version to 260512.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ fs_extra = "1.3.0"
 futures = "0.3.24"
 futures-async-stream = "0.2.7"
 futures-util = "0.3.24"
-hickory-resolver = "0.25"
+hickory-resolver = "0.26"
 hostname = "0.3.1"
 itertools = "0.13.0"
 log = { version = "0.4.27", features = ["serde", "kv_serde", "kv_unstable_std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "260512.3.0"
+version = "260512.4.0"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false

--- a/crates/client/kvapi/src/testing.rs
+++ b/crates/client/kvapi/src/testing.rs
@@ -15,7 +15,6 @@
 use crate::Key;
 use crate::KeyCodec;
 use crate::StructKey;
-use crate::Value;
 
 #[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq, KeyCodec)]
@@ -35,10 +34,6 @@ pub(crate) struct FooValue;
 
 impl Key for FooKey {
     type ValueType = FooValue;
-}
-
-impl Value for FooValue {
-    type KeyType = FooKey;
 }
 
 #[cfg(test)]

--- a/crates/client/kvapi/src/value.rs
+++ b/crates/client/kvapi/src/value.rs
@@ -14,9 +14,7 @@
 
 use std::fmt::Debug;
 
-use crate as kvapi;
-
 /// A value that can be stored in kvapi::KVApi.
-pub trait Value: Debug {
-    type KeyType: kvapi::Key;
-}
+pub trait Value: Debug {}
+
+impl<V> Value for V where V: Debug {}

--- a/crates/common/runtime-api/src/tokio_impl.rs
+++ b/crates/common/runtime-api/src/tokio_impl.rs
@@ -40,7 +40,7 @@ use crate::TrackingData;
 /// Global DNS resolver instance for TokioRuntime.
 static DNS_RESOLVER: LazyLock<io::Result<TokioResolver>> =
     LazyLock::new(|| match TokioResolver::builder_tokio() {
-        Ok(builder) => Ok(builder.build()),
+        Ok(builder) => builder.build().map_err(io::Error::other),
         Err(e) => Err(io::Error::other(e)),
     });
 
@@ -252,7 +252,7 @@ impl SpawnApi for TokioRuntime {
                 .lookup_ip(&hostname)
                 .await
                 .map_err(|e| io::Error::other(e.to_string()))?;
-            Ok(lookup.into_iter().collect())
+            Ok(lookup.iter().collect())
         })
     }
 

--- a/crates/common/version/src/grpc_changelog.rs
+++ b/crates/common/version/src/grpc_changelog.rs
@@ -174,6 +174,12 @@ pub fn grpc_changelog() -> BTreeMap<Version, GrpcVersionCompat> {
         min_server: ver(260217, 0, 0),
     });
 
+    // 260512.4.0: no grpc compatibility change.
+    m.insert(ver(260512, 4, 0), GrpcVersionCompat {
+        min_client: ver(1, 2, 676),
+        min_server: ver(260217, 0, 0),
+    });
+
     m
 }
 

--- a/crates/common/version/src/lib.rs
+++ b/crates/common/version/src/lib.rs
@@ -140,17 +140,17 @@ mod tests {
 
     #[test]
     fn test_version_string() {
-        assert_eq!(version_str(), "260512.3.0");
+        assert_eq!(version_str(), "260512.4.0");
     }
 
     #[test]
     fn test_semver_components() {
-        assert_eq!(semver_tuple(version()), (260512, 3, 0));
+        assert_eq!(semver_tuple(version()), (260512, 4, 0));
     }
 
     #[test]
     fn test_semver_display() {
-        assert_eq!(version().to_semver().to_string(), "260512.3.0");
+        assert_eq!(version().to_semver().to_string(), "260512.4.0");
     }
 
     #[test]


### PR DESCRIPTION

## Changelog

##### chore: bump version to 260512.4.0
# Summary

Advance the databend-meta workspace version for the next 260512 patch
release.

# Details

The version crate expectations and gRPC compatibility changelog now
include 260512.4.0 with no compatibility floor changes, matching the
workspace package version.


##### change: make kvapi Value a blanket marker trait
# Summary

The `Value` trait previously carried a `KeyType: kvapi::Key` associated
type, back-referencing each value to its key. That associated type is
removed: `Value` is now an empty marker bounded only by `Debug`, and a
blanket impl makes every `Debug` type a `Value`, dropping the
value-to-key relationship hook.

# Details

- `Value` no longer declares `KeyType`, decoupling values from keys so
  callers no longer pin a key type per value. The blanket impl means any
  `Debug` type satisfies `Value` without an explicit impl.
- The `FooValue` test helper drops its now-redundant explicit `Value`
  impl, since the blanket impl covers it.

Upgrade tip:

Remove explicit `impl Value for T { type KeyType = ... }` blocks; any
`Debug` type now implements `Value` automatically.

---


