### PR TITLE
fix: upgrade hickory-resolver to 0.26 for RUSTSEC advisories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ fs_extra = "1.3.0"
 futures = "0.3.24"
 futures-async-stream = "0.2.7"
 futures-util = "0.3.24"
-hickory-resolver = "0.25"
+hickory-resolver = "0.26"
 hostname = "0.3.1"
 itertools = "0.13.0"
 log = { version = "0.4.27", features = ["serde", "kv_serde", "kv_unstable_std"] }

--- a/crates/common/runtime-api/src/tokio_impl.rs
+++ b/crates/common/runtime-api/src/tokio_impl.rs
@@ -21,6 +21,7 @@ use std::thread::JoinHandle as ThreadJoinHandle;
 use std::time::Duration;
 
 use hickory_resolver::TokioResolver;
+use hickory_resolver::config::LookupIpStrategy;
 use tokio::runtime::Handle;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
@@ -40,7 +41,14 @@ use crate::TrackingData;
 /// Global DNS resolver instance for TokioRuntime.
 static DNS_RESOLVER: LazyLock<io::Result<TokioResolver>> =
     LazyLock::new(|| match TokioResolver::builder_tokio() {
-        Ok(builder) => Ok(builder.build()),
+        Ok(mut builder) => {
+            // hickory 0.26 changed the default lookup strategy to `Ipv6AndIpv4`
+            // (AAAA before A). Pin the pre-0.26 `Ipv4thenIpv6` order so that
+            // `localhost` resolves to 127.0.0.1 first, matching IPv4-bound
+            // listeners.
+            builder.options_mut().ip_strategy = LookupIpStrategy::Ipv4thenIpv6;
+            builder.build().map_err(io::Error::other)
+        }
         Err(e) => Err(io::Error::other(e)),
     });
 
@@ -252,7 +260,7 @@ impl SpawnApi for TokioRuntime {
                 .lookup_ip(&hostname)
                 .await
                 .map_err(|e| io::Error::other(e.to_string()))?;
-            Ok(lookup.into_iter().collect())
+            Ok(lookup.iter().collect())
         })
     }
 


### PR DESCRIPTION

## Changelog

##### fix: upgrade hickory-resolver to 0.26 for RUSTSEC advisories
# Summary

The security audit CI step failed because `cargo audit` flagged two
denial-of-service advisories in `hickory-proto 0.25.2`, pulled in
transitively through `hickory-resolver`. Upgrading `hickory-resolver` to
0.26 resolves `hickory-proto` to 0.26.1, which clears both advisories.

# Details

- Bump `hickory-resolver` from 0.25 to 0.26. This brings `hickory-proto`
  0.26.1, fixing RUSTSEC-2026-0119 (patched >= 0.26.1) and avoiding
  RUSTSEC-2026-0118 (unaffected >= 0.26.0-beta.1, since the affected
  `DnssecDnsHandle` moved to the new `hickory-net` crate in 0.26).
- Adapt the Tokio DNS resolver to the 0.26 API: `ResolverBuilder::build`
  is now fallible, so its error is mapped into `io::Error`; and `LookupIp`
  no longer implements `IntoIterator`, so iteration uses `iter()`, which
  yields `IpAddr`.

---

- Bug Fix
