### PR TITLE
chore: bump version to 260512.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "260512.4.0"
+version = "260512.5.0"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false

--- a/crates/common/version/src/grpc_changelog.rs
+++ b/crates/common/version/src/grpc_changelog.rs
@@ -180,6 +180,12 @@ pub fn grpc_changelog() -> BTreeMap<Version, GrpcVersionCompat> {
         min_server: ver(260217, 0, 0),
     });
 
+    // 260512.5.0: no grpc compatibility change.
+    m.insert(ver(260512, 5, 0), GrpcVersionCompat {
+        min_client: ver(1, 2, 676),
+        min_server: ver(260217, 0, 0),
+    });
+
     m
 }
 

--- a/crates/common/version/src/lib.rs
+++ b/crates/common/version/src/lib.rs
@@ -140,17 +140,17 @@ mod tests {
 
     #[test]
     fn test_version_string() {
-        assert_eq!(version_str(), "260512.4.0");
+        assert_eq!(version_str(), "260512.5.0");
     }
 
     #[test]
     fn test_semver_components() {
-        assert_eq!(semver_tuple(version()), (260512, 4, 0));
+        assert_eq!(semver_tuple(version()), (260512, 5, 0));
     }
 
     #[test]
     fn test_semver_display() {
-        assert_eq!(version().to_semver().to_string(), "260512.4.0");
+        assert_eq!(version().to_semver().to_string(), "260512.5.0");
     }
 
     #[test]

--- a/crates/server/types/src/lib.rs
+++ b/crates/server/types/src/lib.rs
@@ -95,7 +95,9 @@ pub use protobuf::txn_condition;
 pub use protobuf::txn_condition::ConditionResult;
 pub use protobuf::txn_op;
 pub use protobuf::txn_op_response;
+pub use state_machine_api::KVMeta;
 pub use state_machine_api::SeqV;
+pub use state_machine_api::SeqValue;
 
 pub use crate::cmd::Cmd;
 pub use crate::cmd::CmdContext;


### PR DESCRIPTION

## Changelog

##### chore: bump version to 260512.5.0
# Summary

Advance the databend-meta workspace version for the next 260512 patch
release after re-exporting `KVMeta` and `SeqValue` from `databend-meta-types`.

# Details

The version crate expectations and gRPC compatibility changelog now include
260512.5.0 with no compatibility floor changes, matching the workspace
package version.


##### feat: re-export KVMeta and SeqValue from state_machine_api
# Summary

Surface `KVMeta` and `SeqValue` directly from the `databend-meta-types` crate
root, alongside the existing `SeqV` re-export, so downstream code can name
these types without depending on `state_machine_api` directly.

---


