### PR TITLE
chore: bump version to 260628.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ databend-meta-version = { path = "crates/common/version" }
 base2histogram = "0.2.3"
 databend-base = "0.4.0"
 map-api = "0.4.2"
-openraft = { version = "=0.10.0-alpha.27", features = ["serde", "tracing-log", "runtime-stats"] }
+openraft = { version = "=0.10.0-alpha.28", features = ["serde", "tracing-log", "runtime-stats"] }
 sled = { version = "0.34", default-features = false }
 state-machine-api = "0.3.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "260628.0.0"
+version = "260628.1.0"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false

--- a/crates/common/version/src/grpc_changelog.rs
+++ b/crates/common/version/src/grpc_changelog.rs
@@ -192,6 +192,12 @@ pub fn grpc_changelog() -> BTreeMap<Version, GrpcVersionCompat> {
         min_server: ver(260217, 0, 0),
     });
 
+    // 260628.1.0: no grpc compatibility change.
+    m.insert(ver(260628, 1, 0), GrpcVersionCompat {
+        min_client: ver(1, 2, 676),
+        min_server: ver(260217, 0, 0),
+    });
+
     m
 }
 

--- a/crates/common/version/src/lib.rs
+++ b/crates/common/version/src/lib.rs
@@ -140,17 +140,17 @@ mod tests {
 
     #[test]
     fn test_version_string() {
-        assert_eq!(version_str(), "260628.0.0");
+        assert_eq!(version_str(), "260628.1.0");
     }
 
     #[test]
     fn test_semver_components() {
-        assert_eq!(semver_tuple(version()), (260628, 0, 0));
+        assert_eq!(semver_tuple(version()), (260628, 1, 0));
     }
 
     #[test]
     fn test_semver_display() {
-        assert_eq!(version().to_semver().to_string(), "260628.0.0");
+        assert_eq!(version().to_semver().to_string(), "260628.1.0");
     }
 
     #[test]

--- a/crates/tests/raft-protocol-compat/bin-current/Cargo.lock
+++ b/crates/tests/raft-protocol-compat/bin-current/Cargo.lock
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta"
-version = "260628.0.0"
+version = "260628.1.0"
 dependencies = [
  "anyerror",
  "anyhow",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-base"
-version = "260628.0.0"
+version = "260628.1.0"
 dependencies = [
  "anyerror",
  "deepsize",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client"
-version = "260628.0.0"
+version = "260628.1.0"
 dependencies = [
  "anyerror",
  "arrow-flight",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client-types"
-version = "260628.0.0"
+version = "260628.1.0"
 dependencies = [
  "anyerror",
  "databend-meta-proto",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi"
-version = "260628.0.0"
+version = "260628.1.0"
 dependencies = [
  "async-trait",
  "databend-meta-client-types",
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi-test-suite"
-version = "260628.0.0"
+version = "260628.1.0"
 dependencies = [
  "anyhow",
  "databend-meta-client-types",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-proto"
-version = "260628.0.0"
+version = "260628.1.0"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -1122,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-raft-store"
-version = "260628.0.0"
+version = "260628.1.0"
 dependencies = [
  "anyerror",
  "anyhow",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-runtime-api"
-version = "260628.0.0"
+version = "260628.1.0"
 dependencies = [
  "env_logger",
  "hickory-resolver",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-sled-store"
-version = "260628.0.0"
+version = "260628.1.0"
 dependencies = [
  "anyerror",
  "byteorder",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-types"
-version = "260628.0.0"
+version = "260628.1.0"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-version"
-version = "260628.0.0"
+version = "260628.1.0"
 dependencies = [
  "semver",
 ]

--- a/crates/tests/raft-protocol-compat/bin-current/Cargo.lock
+++ b/crates/tests/raft-protocol-compat/bin-current/Cargo.lock
@@ -2682,9 +2682,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openraft"
-version = "0.10.0-alpha.27"
+version = "0.10.0-alpha.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "543cde97b501169472efb6d5724c9c44531dfd7c5acf6ea1399ea39e4fecb727"
+checksum = "0456aaaa818f1bd12179999d4ebbefc8f0a14091a9c6481cfda4f3ef93e76ac4"
 dependencies = [
  "anyerror",
  "backoff-series",
@@ -2712,9 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-macros"
-version = "0.10.0-alpha.27"
+version = "0.10.0-alpha.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d43c6ef109db505b8ef57de389b34d54927181f3a07819f09c9f0a6cf0ff72c"
+checksum = "1db90aa6d2074d963f8ca2360b146f2423fe914e336c8e66aeb6c266ef295cf9"
 dependencies = [
  "chrono",
  "proc-macro2",
@@ -2725,9 +2725,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt"
-version = "0.10.0-alpha.27"
+version = "0.10.0-alpha.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd3e555284a21902ba525163451fb86c24329e8617143387b0dbddfd7e362de9"
+checksum = "5d9d3c0616bcb3be41c1ac5743cf60a3cbc73f62ab2458527b40079ce3d077c9"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -2738,9 +2738,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt-tokio"
-version = "0.10.0-alpha.27"
+version = "0.10.0-alpha.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2514284b14f28321f8a5614bf82ebae5e2bf8a444d6d879a460a684f71b5c2f7"
+checksum = "f6a3c58d8a68bd8f6398fde62afde01aa876ad412a10f86c8aa341d833490796"
 dependencies = [
  "futures-util",
  "openraft-rt",

--- a/crates/tests/raft-protocol-compat/bin-current/Cargo.toml
+++ b/crates/tests/raft-protocol-compat/bin-current/Cargo.toml
@@ -19,7 +19,7 @@ databend-meta-runtime-api = { path = "../../../common/runtime-api" }
 databend-meta-types = { path = "../../../server/types" }
 env_logger = "0.11"
 log = "0.4"
-openraft = "=0.10.0-alpha.27"
+openraft = "=0.10.0-alpha.28"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1.35", features = ["full"] }


### PR DESCRIPTION

## Changelog

##### chore: bump version to 260628.1.0
# Summary

Bump the workspace release version from 260628.0.0 to 260628.1.0. This
release carries no gRPC or raft protocol compatibility change; it packages
the OpenRaft alpha.28 upgrade.

# Details

The version crate keeps compatibility metadata in lockstep with the current
release, and a unit test requires the gRPC changelog to hold an entry for
the build version. Add a 260628.1.0 changelog entry (min client/server
unchanged at 1.2.676 / 260217.0.0) and update the version-string
assertions to match.

Refresh the `raft-protocol-compat/bin-current` lockfile so its
databend-meta path-dependency entries track the new 260628.1.0 version.


##### chore: upgrade OpenRaft to alpha.28
# Summary

Bump the pinned OpenRaft dependency from =0.10.0-alpha.27 to
=0.10.0-alpha.28. The workspace builds without source changes; the upgrade
is taken for two consensus-layer bug fixes relevant to databend-meta as a
raft consumer.

# Details

- fix: `recv_msg` no longer hangs forever when a state machine drops an
  `ApplyResponder` without calling `send()`. Such a dropped responder used
  to leave `client_write` waiting on a core that never stops; the wait is
  now bounded and returns `Fatal::Stopped` (openraft #1816).
- fix: stale replication acks are rejected after a follower log reversion.
  In pipeline (`LogsSince`) mode many acks share one `InflightId`, so acks
  queued before a reset could advance the matched index over reverted logs
  (a false quorum) or replay an already-consumed command; both are now
  suppressed.
- The remaining changes are supporting work: a new
  `Watch::borrow_and_update()` used by the ack fix, plus internal
  `VecProgress` refactoring with no public API change.
- Propagate the bump to the standalone `raft-protocol-compat/bin-current`
  compat fixture, which is its own workspace and pins OpenRaft directly:
  update its pin to =0.10.0-alpha.28 and refresh its lockfile so it
  resolves against the workspace crates.

---


