### PR TITLE
chore: list releases through 260712 in raft-compat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "260712.0.0"
+version = "260712.1.0"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false

--- a/crates/common/version/src/bin/raft-compat.rs
+++ b/crates/common/version/src/bin/raft-compat.rs
@@ -58,7 +58,7 @@ fn candidate_versions() -> Vec<Version> {
         versions.push(Version::new(1, 2, patch));
     }
 
-    for minor in 0..=10 {
+    for minor in 0..=14 {
         versions.push(Version::new(260205, minor, 0));
     }
     for minor in 0..=10 {
@@ -67,10 +67,13 @@ fn candidate_versions() -> Vec<Version> {
     for minor in 0..=3 {
         versions.push(Version::new(260428, minor, 0));
     }
-    for minor in 0..=3 {
+    for minor in 0..=5 {
         versions.push(Version::new(260512, minor, 0));
     }
-    versions.push(Version::new(260628, 0, 0));
+    for minor in 0..=1 {
+        versions.push(Version::new(260628, minor, 0));
+    }
+    versions.push(Version::new(260712, 0, 0));
 
     versions
 }

--- a/crates/common/version/src/grpc_changelog.rs
+++ b/crates/common/version/src/grpc_changelog.rs
@@ -204,6 +204,12 @@ pub fn grpc_changelog() -> BTreeMap<Version, GrpcVersionCompat> {
         min_server: ver(260217, 0, 0),
     });
 
+    // 260712.1.0: no grpc compatibility change.
+    m.insert(ver(260712, 1, 0), GrpcVersionCompat {
+        min_client: ver(1, 2, 676),
+        min_server: ver(260217, 0, 0),
+    });
+
     m
 }
 

--- a/crates/common/version/src/lib.rs
+++ b/crates/common/version/src/lib.rs
@@ -140,17 +140,17 @@ mod tests {
 
     #[test]
     fn test_version_string() {
-        assert_eq!(version_str(), "260712.0.0");
+        assert_eq!(version_str(), "260712.1.0");
     }
 
     #[test]
     fn test_semver_components() {
-        assert_eq!(semver_tuple(version()), (260712, 0, 0));
+        assert_eq!(semver_tuple(version()), (260712, 1, 0));
     }
 
     #[test]
     fn test_semver_display() {
-        assert_eq!(version().to_semver().to_string(), "260712.0.0");
+        assert_eq!(version().to_semver().to_string(), "260712.1.0");
     }
 
     #[test]

--- a/crates/tests/raft-protocol-compat/bin-current/Cargo.lock
+++ b/crates/tests/raft-protocol-compat/bin-current/Cargo.lock
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta"
-version = "260712.0.0"
+version = "260712.1.0"
 dependencies = [
  "anyerror",
  "anyhow",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-base"
-version = "260712.0.0"
+version = "260712.1.0"
 dependencies = [
  "anyerror",
  "deepsize",
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client"
-version = "260712.0.0"
+version = "260712.1.0"
 dependencies = [
  "anyerror",
  "arrow-flight",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client-types"
-version = "260712.0.0"
+version = "260712.1.0"
 dependencies = [
  "anyerror",
  "databend-meta-proto",
@@ -1112,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi"
-version = "260712.0.0"
+version = "260712.1.0"
 dependencies = [
  "async-trait",
  "databend-meta-client-types",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi-test-suite"
-version = "260712.0.0"
+version = "260712.1.0"
 dependencies = [
  "anyhow",
  "databend-meta-client-types",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-proto"
-version = "260712.0.0"
+version = "260712.1.0"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-raft-store"
-version = "260712.0.0"
+version = "260712.1.0"
 dependencies = [
  "anyerror",
  "anyhow",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-runtime-api"
-version = "260712.0.0"
+version = "260712.1.0"
 dependencies = [
  "env_logger",
  "hickory-resolver",
@@ -1214,7 +1214,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-sled-store"
-version = "260712.0.0"
+version = "260712.1.0"
 dependencies = [
  "anyerror",
  "byteorder",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-types"
-version = "260712.0.0"
+version = "260712.1.0"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-version"
-version = "260712.0.0"
+version = "260712.1.0"
 dependencies = [
  "semver",
 ]


### PR DESCRIPTION

## Changelog

##### chore: list releases through 260712 in raft-compat
# Summary

Extend the release list the raft-compat tool reports on. It had gone stale
after 260628.0.0, so the printed raft protocol compatibility table omitted
every newer release — including 260712.0.0, where the compatibility floor
actually moved.

# Details

The tool computes each range from RaftSpec, so the ranges were already
correct; only the enumerated node versions were behind. With the newer
releases included, the table now shows 260712.0.0 at [1.2.818, ∞) — the
raised floor from requiring SnapshotV004 — against [1.2.547, ∞) on the
releases before it.

---


