### PR TITLE
fix: fail startup when the raft service port is in use

### DIFF
--- a/crates/server/service/src/meta_node/meta_node.rs
+++ b/crates/server/service/src/meta_node/meta_node.rs
@@ -92,6 +92,7 @@ use tokio::sync::watch;
 use tokio::time::Instant;
 use tokio::time::sleep;
 use tonic::Status;
+use tonic::transport::server::TcpIncoming;
 use watcher::EventFilter;
 use watcher::dispatch::Command;
 use watcher::dispatch::Dispatcher;
@@ -241,15 +242,27 @@ impl<SP: SpawnApi> MetaNode<SP> {
         let socket_addr = ip_port.parse::<std::net::SocketAddr>()?;
         let node_id = meta_node.raft_store.id;
 
+        // Bind before spawning: if the port is taken, startup must fail loudly.
+        // `serve_with_shutdown()` binds inside the spawned task, where the error is
+        // only observed when the task is joined at shutdown. Until then the node
+        // reports a successful start while having no raft service at all.
+        let incoming = TcpIncoming::bind(socket_addr)
+            .map_err(|e| {
+                MetaNetworkError::BadAddressFormat(
+                    AnyError::new(&e)
+                        .add_context(|| format!("bind raft service to {}", socket_addr)),
+                )
+            })?
+            .with_nodelay(Some(true));
+
         let srv = tonic::transport::Server::builder()
-            .tcp_nodelay(true)
             // .concurrency_limit_per_connection()
             // .timeout(Duration::from_secs(60))
             .add_service(raft_server);
 
         let h = SP::spawn(
             async move {
-                srv.serve_with_shutdown(socket_addr, async move {
+                srv.serve_with_incoming_shutdown(incoming, async move {
                     let _ = running_rx.changed().await;
                     info!(
                         "running_rx for Raft server received, shutting down: id={} {} ",
@@ -740,12 +753,12 @@ impl<SP: SpawnApi> MetaNode<SP> {
                     Err(api_err) => {
                         warn!("{} while joining cluster via {}", api_err, addr);
                         let can_retry = api_err.is_retryable();
+                        errors.push(api_err);
 
                         if can_retry {
                             sleep(Duration::from_millis(1_000)).await;
                             continue;
                         } else {
-                            errors.push(api_err);
                             break;
                         }
                     }

--- a/crates/server/service/src/meta_node/meta_worker.rs
+++ b/crates/server/service/src/meta_node/meta_worker.rs
@@ -60,6 +60,7 @@ impl<RT: RuntimeApi> MetaWorker<RT> {
                     Ok(x) => x,
                     Err(e) => {
                         error!("Failed to start MetaNode: {}", e);
+                        ret_tx.send(Err(e)).ok();
                         return;
                     }
                 };
@@ -74,7 +75,7 @@ impl<RT: RuntimeApi> MetaWorker<RT> {
                 let handle = MetaHandle::<RT>::new(id, handle_tx, rt_for_handle);
 
                 ret_tx
-                    .send(handle)
+                    .send(Ok(handle))
                     .inspect_err(|_meta_handle| {
                         error!("MetaWorker::work stopped before sending handle")
                     })
@@ -94,7 +95,7 @@ impl<RT: RuntimeApi> MetaWorker<RT> {
                 "MetaWorker::work stopped before sending handle: {}",
                 e
             ))
-        })?;
+        })??;
 
         Ok(meta_handle)
     }

--- a/crates/server/service/tests/it/meta_node/meta_node_lifecycle.rs
+++ b/crates/server/service/tests/it/meta_node/meta_node_lifecycle.rs
@@ -67,6 +67,32 @@ async fn test_meta_node_boot() -> anyhow::Result<()> {
 
 #[test(harness = meta_service_test_harness::<TokioRuntime, _, _>)]
 #[fastrace::trace]
+async fn test_meta_node_boot_raft_port_in_use() -> anyhow::Result<()> {
+    // A raft port that can not be bound must fail startup. Otherwise the node
+    // reports a successful boot while serving no raft traffic at all, and peers
+    // trying to join it only see connection errors.
+
+    let tc = MetaSrvTestContext::<TokioRuntime>::new(0);
+    let listen = tc.config.raft_config.raft_api_listen_host_endpoint();
+
+    let _occupied = std::net::TcpListener::bind(listen.to_string())?;
+
+    let res = MetaNode::<TokioRuntime>::boot(&tc.config).await;
+    let Err(err) = res else {
+        unreachable!("boot must fail when the raft port is occupied");
+    };
+
+    assert!(
+        err.to_string()
+            .contains(&format!("bind raft service to {}", listen)),
+        "want a raft bind failure, got: {}",
+        err
+    );
+    Ok(())
+}
+
+#[test(harness = meta_service_test_harness::<TokioRuntime, _, _>)]
+#[fastrace::trace]
 async fn test_meta_node_graceful_shutdown() -> anyhow::Result<()> {
     // - Start a leader then shutdown.
 


### PR DESCRIPTION

## Changelog

##### fix: fail startup when the raft service port is in use
# Summary

Booting a meta node whose raft port cannot be bound now fails with the
bind error, instead of reporting a successful start while serving no
raft traffic.

# Details

The raft gRPC server was started with `serve_with_shutdown()`, which
binds inside the spawned task. A bind failure was therefore only
observed when that task was joined at shutdown; until then the node
looked healthy while peers attempting to join it saw nothing but
connection errors. The listener is now bound before the task is
spawned, so the failure propagates out of startup.

`create_meta_worker` logged the `MetaNode::start` error and dropped the
return channel, so the caller received a "stopped before sending
handle" channel-closed message rather than the actual cause. The
startup error is now sent back over that channel.

The join loop recorded only non-retryable errors, so a join that
exhausted its retries on retryable failures reported an empty error
list. Every attempt's error is now collected.

---

- Bug Fix
