### PR TITLE
docs: raft-secret: record that the config mapping landed

### DIFF
--- a/crates/server/service/src/api/grpc/grpc_service.rs
+++ b/crates/server/service/src/api/grpc/grpc_service.rs
@@ -579,8 +579,10 @@ impl<SP: SpawnApi> MetaService for MetaServiceImpl<SP> {
     /// The exported data is a series of JSON encoded strings of `RaftStoreEntry`.
     async fn export(
         &self,
-        _request: Request<databend_meta_types::protobuf::Empty>,
+        request: Request<databend_meta_types::protobuf::Empty>,
     ) -> Result<Response<Self::ExportStream>, Status> {
+        self.check_token(request.metadata())?;
+
         let guard = InFlightRead::guard();
 
         let meta_handle = self.try_get_meta_handle()?;
@@ -614,6 +616,8 @@ impl<SP: SpawnApi> MetaService for MetaServiceImpl<SP> {
         &self,
         request: Request<pb::ExportRequest>,
     ) -> Result<Response<Self::ExportV1Stream>, Status> {
+        self.check_token(request.metadata())?;
+
         let guard = InFlightRead::guard();
 
         let meta_handle = self.try_get_meta_handle()?;
@@ -643,6 +647,8 @@ impl<SP: SpawnApi> MetaService for MetaServiceImpl<SP> {
         &self,
         request: Request<KeysLayoutRequest>,
     ) -> Result<Response<Self::SnapshotKeysLayoutStream>, Status> {
+        self.check_token(request.metadata())?;
+
         let guard = InFlightRead::guard();
 
         let layout_request = request.into_inner();
@@ -668,6 +674,8 @@ impl<SP: SpawnApi> MetaService for MetaServiceImpl<SP> {
         &self,
         request: Request<WatchRequest>,
     ) -> Result<Response<Self::WatchStream>, Status> {
+        self.check_token(request.metadata())?;
+
         let watch = request.into_inner();
 
         let meta_handle = self.try_get_meta_handle()?;
@@ -696,8 +704,10 @@ impl<SP: SpawnApi> MetaService for MetaServiceImpl<SP> {
 
     async fn get_cluster_status(
         &self,
-        _request: Request<Empty>,
+        request: Request<Empty>,
     ) -> Result<Response<ClusterStatus>, Status> {
+        self.check_token(request.metadata())?;
+
         let _guard = InFlightRead::guard();
 
         let meta_handle = self.try_get_meta_handle()?;
@@ -752,6 +762,8 @@ impl<SP: SpawnApi> MetaService for MetaServiceImpl<SP> {
         &self,
         request: Request<Empty>,
     ) -> Result<Response<ClientInfo>, Status> {
+        self.check_token(request.metadata())?;
+
         let _guard = InFlightRead::guard();
 
         let r = request.remote_addr();

--- a/crates/server/service/tests/it/grpc/metasrv_grpc_export.rs
+++ b/crates/server/service/tests/it/grpc/metasrv_grpc_export.rs
@@ -18,12 +18,14 @@ use databend_meta_kvapi::KvApiExt;
 use databend_meta_runtime_api::TokioRuntime;
 use databend_meta_types::UpsertKV;
 use databend_meta_types::protobuf as pb;
+use databend_meta_types::protobuf::meta_service_client::MetaServiceClient;
 use log::info;
 use pretty_assertions::assert_eq;
 use regex::Regex;
 use test_harness::test;
 use tokio::time::sleep;
 use tokio_stream::StreamExt;
+use tonic::Code;
 
 use crate::testing::meta_service_test_harness;
 use crate::tests::service::grpc_client;
@@ -135,6 +137,39 @@ async fn test_export() -> anyhow::Result<()> {
         .collect::<Vec<_>>();
 
     assert_eq!(want, lines);
+
+    Ok(())
+}
+
+/// Both export RPCs stream the entire store -- header, raft state, log and
+/// state machine -- to whoever asks, so a caller that never handshook must not
+/// reach either of them.
+///
+/// Both are asserted because the client picks between them by server version
+/// (`export_from_grpc` falls back to `export` below 1.2.315): leaving one open
+/// leaves the whole dump open.
+///
+/// The client is the generated stub rather than `MetaGrpcClient`, since that
+/// one handshakes before every call and could not express this request.
+#[test(harness = meta_service_test_harness::<TokioRuntime, _, _>)]
+#[fastrace::trace]
+async fn test_export_refuses_a_client_that_did_not_handshake() -> anyhow::Result<()> {
+    let (_tc, addr) = crate::tests::start_metasrv::<TokioRuntime>().await?;
+
+    let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
+
+    let v0 = client.export(pb::Empty {}).await.unwrap_err();
+    let v1 = client
+        .export_v1(pb::ExportRequest { chunk_size: None })
+        .await
+        .unwrap_err();
+
+    for status in [v0, v1] {
+        assert_eq!(status.code(), Code::Unauthenticated);
+        // The message names the missing token, which is what tells this
+        // refusal apart from one the handshake version gate would produce.
+        assert_eq!(status.message(), "Error auth-token-bin is empty");
+    }
 
     Ok(())
 }

--- a/crates/server/service/tests/it/grpc/metasrv_grpc_get_client_info.rs
+++ b/crates/server/service/tests/it/grpc/metasrv_grpc_get_client_info.rs
@@ -13,9 +13,12 @@
 // limitations under the License.
 
 use databend_meta_runtime_api::TokioRuntime;
+use databend_meta_types::protobuf::Empty;
+use databend_meta_types::protobuf::meta_service_client::MetaServiceClient;
 use pretty_assertions::assert_eq;
 use regex::Regex;
 use test_harness::test;
+use tonic::Code;
 
 use crate::testing::meta_service_test_harness;
 use crate::tests::service::grpc_client;
@@ -41,5 +44,35 @@ async fn test_get_client_info() -> anyhow::Result<()> {
     assert_eq!("1.1.1.1:1", masked_addr);
 
     assert!(resp.server_time > Some(1), "server time is returned");
+    Ok(())
+}
+
+/// Both `Empty`-request info RPCs are covered here because there is no test
+/// file for `get_cluster_status` of its own.
+///
+/// Neither returns key-value data, so what they leak is reconnaissance:
+/// `get_cluster_status` gives the node ids, endpoints, versions and raft state
+/// of every member, and `get_client_info` confirms the port is a meta service
+/// and tells the caller which source address the server sees it as.
+///
+/// The client is the generated stub rather than `MetaGrpcClient`, since that
+/// one handshakes before every call and could not express these requests.
+#[test(harness = meta_service_test_harness::<TokioRuntime, _, _>)]
+#[fastrace::trace]
+async fn test_info_rpcs_refuse_a_client_that_did_not_handshake() -> anyhow::Result<()> {
+    let (_tc, addr) = crate::tests::start_metasrv::<TokioRuntime>().await?;
+
+    let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
+
+    let cluster_status = client.get_cluster_status(Empty {}).await.unwrap_err();
+    let client_info = client.get_client_info(Empty {}).await.unwrap_err();
+
+    for status in [cluster_status, client_info] {
+        assert_eq!(status.code(), Code::Unauthenticated);
+        // The message names the missing token, which is what tells this
+        // refusal apart from one the handshake version gate would produce.
+        assert_eq!(status.message(), "Error auth-token-bin is empty");
+    }
+
     Ok(())
 }

--- a/crates/server/service/tests/it/grpc/metasrv_grpc_watch.rs
+++ b/crates/server/service/tests/it/grpc/metasrv_grpc_watch.rs
@@ -42,12 +42,14 @@ use databend_meta_types::protobuf::KvMeta;
 use databend_meta_types::protobuf::SeqV;
 use databend_meta_types::protobuf::TxnRequest;
 use databend_meta_types::protobuf::WatchRequest;
+use databend_meta_types::protobuf::meta_service_client::MetaServiceClient;
 use databend_meta_types::protobuf::watch_request::FilterType;
 use databend_meta_types::txn_condition;
 use databend_meta_types::txn_op;
 use log::info;
 use test_harness::test;
 use tokio::time::sleep;
+use tonic::Code;
 
 use crate::testing::meta_service_test_harness;
 use crate::tests::service::grpc_client;
@@ -626,6 +628,33 @@ async fn test_watch_stream_count() -> anyhow::Result<()> {
 
         assert_eq!(1, got);
     }
+
+    Ok(())
+}
+
+/// `watch` streams every change under a key range for as long as the caller
+/// keeps the stream, so an unauthenticated watcher is a standing leak rather
+/// than a single theft: it never shows up as one large dump the way `export`
+/// does.
+///
+/// The client is the generated stub rather than `MetaGrpcClient`, since that
+/// one handshakes before every call and could not express this request.
+#[test(harness = meta_service_test_harness::<TokioRuntime, _, _>)]
+#[fastrace::trace]
+async fn test_watch_refuses_a_client_that_did_not_handshake() -> anyhow::Result<()> {
+    let (_tc, addr) = crate::tests::start_metasrv::<TokioRuntime>().await?;
+
+    let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
+
+    let status = client
+        .watch(WatchRequest::new(s("a"), None))
+        .await
+        .unwrap_err();
+
+    assert_eq!(status.code(), Code::Unauthenticated);
+    // The message names the missing token, which is what tells this refusal
+    // apart from one the handshake version gate would produce.
+    assert_eq!(status.message(), "Error auth-token-bin is empty");
 
     Ok(())
 }

--- a/crates/server/service/tests/it/grpc/t53_metasrv_grpc_snapshot_keys_layout.rs
+++ b/crates/server/service/tests/it/grpc/t53_metasrv_grpc_snapshot_keys_layout.rs
@@ -18,11 +18,13 @@ use databend_meta_kvapi::KvApiExt;
 use databend_meta_runtime_api::TokioRuntime;
 use databend_meta_types::UpsertKV;
 use databend_meta_types::protobuf as pb;
+use databend_meta_types::protobuf::meta_service_client::MetaServiceClient;
 use log::info;
 use pretty_assertions::assert_eq;
 use test_harness::test;
 use tokio::time::sleep;
 use tokio_stream::StreamExt;
+use tonic::Code;
 
 use crate::testing::meta_service_test_harness;
 use crate::tests::service::grpc_client;
@@ -149,6 +151,32 @@ async fn test_snapshot_keys_layout() -> anyhow::Result<()> {
 
         assert_eq!(results, want);
     }
+
+    Ok(())
+}
+
+/// The key layout is reconnaissance rather than data: it hands out the shape
+/// of the keyspace -- which prefixes exist and how many keys sit under each --
+/// which is what a caller reads before deciding what is worth taking.
+///
+/// The client is the generated stub rather than `MetaGrpcClient`, since that
+/// one handshakes before every call and could not express this request.
+#[test(harness = meta_service_test_harness::<TokioRuntime, _, _>)]
+#[fastrace::trace]
+async fn test_snapshot_keys_layout_refuses_a_client_that_did_not_handshake() -> anyhow::Result<()> {
+    let (_tc, addr) = crate::tests::start_metasrv::<TokioRuntime>().await?;
+
+    let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
+
+    let status = client
+        .snapshot_keys_layout(pb::KeysLayoutRequest { depth: None })
+        .await
+        .unwrap_err();
+
+    assert_eq!(status.code(), Code::Unauthenticated);
+    // The message names the missing token, which is what tells this refusal
+    // apart from one the handshake version gate would produce.
+    assert_eq!(status.message(), "Error auth-token-bin is empty");
 
     Ok(())
 }

--- a/docs/network-exposure.md
+++ b/docs/network-exposure.md
@@ -1,0 +1,73 @@
+# Network Exposure
+
+A `databend-meta` node listens on three ports. They differ in what they check,
+and none of them is safe to reach from outside the cluster's trusted network.
+
+| Port  | Config key          | Serves                                | Checks the caller           |
+|-------|---------------------|---------------------------------------|-----------------------------|
+| raft  | `raft_api_port`     | replication between nodes             | the shared secret, if configured |
+| gRPC  | `grpc_api_address`  | the key-value API, watch, export      | a handshake token -- see below |
+| admin | `admin_api_address` | health, config, metrics, control      | nothing                     |
+
+## The raft port
+
+Raft RPCs carry a shared secret once the cluster is configured for one. See
+[raft-secret-rollout.md](raft-secret-rollout.md) for what that secret covers,
+how to roll it out without downtime, and why it does not replace a trusted
+network: raft connects over cleartext `http://`, so an adversary who can read
+the wire takes the secret out of any RPC and replays it.
+
+This port has no TLS option at all.
+
+## The gRPC port
+
+Every RPC except `handshake` requires the token that `handshake` returns, so a
+client that never handshakes reaches nothing -- not the key-value API, not
+`watch`, not `export`.
+
+That is a smaller guarantee than it sounds. `handshake` issues a token to any
+caller presenting the username `root`. The password travels in the request and
+is never compared against anything, because there is no user table to compare
+it with. The token gate therefore stops a caller that does not speak the
+handshake -- a port scanner, a misconfigured tool, an old client -- and stops
+nobody who chooses to speak it.
+
+Until that changes, treat this port as reachable-means-full-access: whoever can
+open a connection can read and write every key in the store, and can stream the
+whole store out with `export`.
+
+## The admin port
+
+Nothing on this port is authenticated. Alongside the read-only endpoints
+(`/v1/health`, `/v1/config`, `/v1/cluster/status`, `/v1/cluster/nodes`,
+`/v1/metrics`) it serves three that change the cluster:
+
+- `/v1/ctrl/trigger_snapshot`
+- `/v1/ctrl/trigger_transfer_leader` -- moves leadership to a node the caller names
+- `/v1/features/set`
+
+and `/debug/pprof/profile`, which profiles the running process on request.
+
+A single unauthenticated GET can therefore move the leader. Keep this port on a
+management network that no workload can reach.
+
+## What TLS buys here
+
+The gRPC and admin ports each accept a server certificate and key. Both
+configure the server identity only; neither asks the client for a certificate.
+TLS on these ports is transport encryption and nothing more -- it stops someone
+reading the wire, and does not narrow who may connect.
+
+## Data at rest and in backups
+
+Nothing the meta service writes is encrypted. That covers the raft log and
+state machine on disk, the snapshot files (including the ones shipped to a
+joining node over the cleartext raft port), and the JSON that
+`databend-metactl export` produces, which contains every key and value
+verbatim.
+
+Databend keeps stage and connection definitions in meta, and those hold
+object-storage credentials. A snapshot file or an export dump is therefore a
+credential file. Hold it to the same standard as the credentials inside it, and
+do not park backups anywhere the meta cluster's own trust boundary does not
+already cover.

--- a/docs/raft-secret-rollout.md
+++ b/docs/raft-secret-rollout.md
@@ -34,15 +34,13 @@ does not control who may listen.
 
 The `databend-meta` binary is built from the `databend` repository, and it is
 what reads the config file and the command line. The three keys below reach
-this crate only through the raft config that binary maps, and that mapping is a
-separate change in `databend` which has not shipped: no released binary accepts
-them.
+this crate only through the raft config that binary maps, which landed in
+databend PR #20280.
 
-Confirm the binary supports them before starting, by checking that
+Whether the binary in front of you carries that mapping is better answered
+directly than from a version number: confirm that
 `databend-meta --cmd show-config` renders `raft_secret` in its `raft_config`
-section. Until it does, phase 1 cannot be executed, and the rest of this
-document describes what the rollout will look like rather than what can be done
-today.
+section. Do that before starting phase 1.
 
 ## Configuration
 

--- a/docs/raft-secret-rollout.md
+++ b/docs/raft-secret-rollout.md
@@ -35,7 +35,7 @@ does not control who may listen.
 The `databend-meta` binary is built from the `databend` repository, and it is
 what reads the config file and the command line. The three keys below reach
 this crate only through the raft config that binary maps, which landed in
-databend PR #20280.
+[databendlabs/databend#20280](https://github.com/databendlabs/databend/pull/20280).
 
 Whether the binary in front of you carries that mapping is better answered
 directly than from a version number: confirm that


### PR DESCRIPTION

## Changelog

##### docs: raft-secret: record that the config mapping landed
# Summary

The prerequisite no longer tells the reader that no released binary
accepts the three keys and that phase 1 cannot be executed. That
mapping is merged, so the rollout describes something that can be done.

# Details

The databend side merged as PR #20280; #20279, which the earlier
wording was waiting on, was closed unmerged and replaced by it.

The section points at the PR rather than a minimum version because no
tag contains that commit yet, and naming one later would put the
document back in the state this change is fixing. The `show-config`
check is now stated as the thing to trust in preference to a version
number, which keeps it correct as releases come and go.


##### docs: network-exposure: document what each port checks
# Summary

A new document states, per listening port, what a caller must present to
be served, so an operator can decide what to expose without reading the
request handlers.

# Details

It is written to be blunt about what the token checks on the gRPC port
are worth rather than to advertise them. `handshake` issues a token to
anyone presenting the username `root` and never compares the password,
so requiring that token on every other RPC stops a caller that does not
speak the handshake -- a scanner, a misconfigured tool, an old client --
and stops nobody who chooses to. An operator who read "authenticated"
and stopped there would put the trust boundary in the wrong place.

The admin port gets a section of its own because nothing else describes
it: it authenticates nothing, and three of its endpoints change cluster
state through plain GETs, one of them moving leadership to a node the
caller names.

The closing section records that nothing written to disk or to a backup
is encrypted. Databend keeps object-storage credentials in meta, so a
snapshot file and an export dump are credential files and belong under
the same handling as the credentials inside them.

Every claim was verified against the code at this commit.


##### change: service: require a token on every RPC but handshake
# Summary

The six RPCs that still served an unauthenticated caller -- `export`,
`export_v1`, `watch`, `snapshot_keys_layout`, `get_cluster_status` and
`get_client_info` -- now reject one. `handshake` is the only RPC on
`MetaService` that does not check the token.

# Details

Between them the six covered everything the service discloses. `export`
and `export_v1` stream the whole raft store, so one call took every
key; both are gated rather than only the newer one, because the client
picks between them by server version and `databend-metactl` falls back
to `export` against a server below 1.2.315. `watch` subscribes to every
change under a key range and keeps delivering while the caller holds
the stream, which is a standing leak rather than a single theft: unlike
`export` it never appears as one large dump. The other three return no
key-value data and leaked reconnaissance instead -- the shape of the
keyspace, the id and raft state of every member, and confirmation that
the port is a meta service at all.

No caller had to change, which is why none of this needed a permissive
stage. Every path in goes through a client that handshakes first:
`databend-metactl` export, status and keys-layout; both watch entry
points on `MetaGrpcClient`; Databend's own meta store; and the
per-version binaries under `crates/tests/raft-protocol-compat/`. The
admin HTTP API reaches the node in-process through `MetaHandle` and
never uses grpc, and Prometheus scrapes that same admin port.

What this does not buy is authentication. `handshake` issues a token to
anyone presenting the username `root` and never compares the password,
so the gate stops a caller that does not speak the handshake -- a
scanner, a misconfigured tool, an old client -- and stops nobody who
chooses to speak it.

Upgrade tip:

Calling any of the six on a bare `MetaServiceClient` now returns
`Unauthenticated`. Reach them through `MetaGrpcClient`, or handshake and
carry the returned token in the `auth-token-bin` metadata key.

---


